### PR TITLE
JBIDE-12955 fix relativepath.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>base.all</artifactId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>runtime</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>tests</artifactId>

--- a/tests/scripts/installation-updates/pom.xml
+++ b/tests/scripts/installation-updates/pom.xml
@@ -9,7 +9,6 @@
 		<groupId>org.jboss.tools.tests</groupId>
   		<artifactId>scripts</artifactId>
   		<version>3.4.0-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<dependencies>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>usage</artifactId>


### PR DESCRIPTION
I suggest we don't use the root of "uber" components as the parent since components like central would overlap in naming and maven in central is not really a child of central. WDYT ?
