### PR TITLE
fix pom hierarchy for submodules

### DIFF
--- a/all-tests/pom.xml
+++ b/all-tests/pom.xml
@@ -4,11 +4,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>base.all</artifactId>
+		<artifactId>base</artifactId>
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools</groupId>
-	<artifactId>base.all.tests</artifactId>
+	<groupId>org.jboss.tools.base</groupId>
+	<artifactId>all-tests</artifactId>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,9 +4,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>base</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath>../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
-	<artifactId>base.all</artifactId>
+	<artifactId>base</artifactId>
 	<version>4.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	 <!--

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -4,9 +4,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>base</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>runtime</artifactId>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -4,11 +4,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>base.all</artifactId>
+		<artifactId>base</artifactId>
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools</groupId>
-	<artifactId>base.site</artifactId>
+	<groupId>org.jboss.tools.base</groupId>
+	<artifactId>site</artifactId>
 	<packaging>eclipse-repository</packaging>
 
 	<properties>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -3,9 +3,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>base</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>tests</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -4,9 +4,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>base</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>usage</artifactId>


### PR DESCRIPTION
common, tests, usage, all-tests, runtime and site reference to base/pom.xml as a parent.
GAV updated for pom.xml, site/pom.xml and all-tests/pom.xml
