### PR TITLE
JBDS-2291 - Installing Mylyn from alpha2 extras attempts to install Mylyn 3.6 - should be 3.8 

### DIFF
--- a/common/plugins/org.jboss.tools.common.mylyn/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.mylyn/META-INF/MANIFEST.MF
@@ -6,11 +6,11 @@ Bundle-Version: 3.4.0.qualifier
 Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.jboss.tools.common.mylyn,
- org.eclipse.mylyn.commons.core;bundle-version="[3.6.0,4.0.0)",
- org.eclipse.mylyn.commons.ui;bundle-version="[3.6.1,4.0.0)",
- org.eclipse.mylyn.tasks.core;bundle-version="[3.6.1,4.0.0)",
- org.eclipse.mylyn.tasks.ui;bundle-version="[3.6.5,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.7.0,4.3.0)",
+ org.eclipse.mylyn.commons.core;bundle-version="[3.8.0,4.0.0)",
+ org.eclipse.mylyn.commons.ui;bundle-version="[3.8.0,4.0.0)",
+ org.eclipse.mylyn.tasks.core;bundle-version="[3.8.0,4.0.0)",
+ org.eclipse.mylyn.tasks.ui;bundle-version="[3.8.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.8.0,4.3.0)",
  com.atlassian.connector.eclipse.commons.core;bundle-version="3.0.2";resolution:=optional,
  com.atlassian.connector.eclipse.commons.ui;bundle-version="3.0.2";resolution:=optional,
  com.atlassian.connector.eclipse.jira.core;bundle-version="3.0.2";resolution:=optional,


### PR DESCRIPTION
Installing Mylyn from alpha2 extras attempts to install Mylyn 3.6 - should be 3.8 
