### PR TITLE
https://issues.jboss.org/browse/JBIDE-13005 test failure in CommonELAllTests

### DIFF
--- a/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/TypeInfoCollector.java
+++ b/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/TypeInfoCollector.java
@@ -530,6 +530,7 @@ public class TypeInfoCollector {
 				Map<String, Type> parametersOfDeclaringType = new HashMap<String, Type>();
 				TypeInfo parentTypeInfo = (TypeInfo)getParentMember();
 				parentTypeInfo.initializeParameters();
+				declaratedType.initializeParameters();
 				for (int i = 0; i < fParametersNamesOfDeclaringType.length; i++) {
 					String parameterName = getParameterNameFromType(fParametersNamesOfDeclaringType[i]);
 					Type paramType = declaratedType.getParameterType(parameterName);

--- a/common/tests/org.jboss.tools.common.el.core.test/projects/JavaProject1/src/test/Test2List.java
+++ b/common/tests/org.jboss.tools.common.el.core.test/projects/JavaProject1/src/test/Test2List.java
@@ -1,0 +1,8 @@
+package test;
+
+import java.util.ArrayList;
+
+public abstract class Test2List<E> implements TestI3List<E> {
+
+	private static final long serialVersionUID = -7718691817083841336L;
+}

--- a/common/tests/org.jboss.tools.common.el.core.test/projects/JavaProject1/src/test/TestI2List.java
+++ b/common/tests/org.jboss.tools.common.el.core.test/projects/JavaProject1/src/test/TestI2List.java
@@ -1,0 +1,5 @@
+package test;
+
+public interface TestI2List<E> extends TestIList<E> {
+
+}

--- a/common/tests/org.jboss.tools.common.el.core.test/projects/JavaProject1/src/test/TestI3List.java
+++ b/common/tests/org.jboss.tools.common.el.core.test/projects/JavaProject1/src/test/TestI3List.java
@@ -1,0 +1,5 @@
+package test;
+
+public interface TestI3List<E> extends TestI2List<E> {
+
+}

--- a/common/tests/org.jboss.tools.common.el.core.test/projects/JavaProject1/src/test/TestIList.java
+++ b/common/tests/org.jboss.tools.common.el.core.test/projects/JavaProject1/src/test/TestIList.java
@@ -1,0 +1,7 @@
+package test;
+
+import java.util.List;
+
+public interface TestIList<E> extends List<E> {
+
+}

--- a/common/tests/org.jboss.tools.common.el.core.test/projects/JavaProject2/src/test/CollectionBean.java
+++ b/common/tests/org.jboss.tools.common.el.core.test/projects/JavaProject2/src/test/CollectionBean.java
@@ -2,5 +2,5 @@ package test;
 
 public class CollectionBean {
 
-	public TestList<Test> tests;
+	public Test2List<Test> tests;
 }


### PR DESCRIPTION
test failure in org.jboss.tools.common.el.core.test.CommonELAllTests

TypeMemberInfo.initializeParameters() was not initializing parameters of declaratedType. In complex hierarchies, that type may remain not initialized with parentTypeInfo.
