### PR TITLE
https://issues.jboss.org/browse/JBIDE-13073 

### DIFF
--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/outline/XModelObjectContentOutlineProvider.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/outline/XModelObjectContentOutlineProvider.java
@@ -143,7 +143,11 @@ public class XModelObjectContentOutlineProvider extends ContentOutlinePage {
 					return;
 				}
 				ISelection validContentSelection = mapSelection(getTreeViewer(), selection);
-				getTreeViewer().refresh(true);
+// Why this refresh was needed? It deteriorates performance.
+// If some problems with selection in outline appear, 
+// they should be treated in a different way than 
+// completely refresh the viewer at each selection change.
+//				getTreeViewer().refresh(true);
 				boolean isLinked = true; ///getConfiguration().isLinkedWithEditor(getTreeViewer());
 				if (isLinked) {
 					getTreeViewer().setSelection(validContentSelection, true);


### PR DESCRIPTION
Outline of JBossTools editors performs complete refresh at each selection change.
