### PR TITLE
Increase timeout for InstallFromCentral

### DIFF
--- a/tests/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/InstallFromCentralTest.java
+++ b/tests/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/InstallFromCentralTest.java
@@ -77,7 +77,7 @@ public class InstallFromCentralTest extends SWTBotEclipseTestCase {
 			public String getFailureMessage() {
 				return "Blocking while calculating deps";
 			}
-		}, 10 * 60000); // 10 minutes timeout
+		}, 15 * 60000); // 15 minutes timeout
 		if (this.bot.activeShell().getText().equals("Problem Occured")) {
 			String reason = this.bot.text().getText();
 			Assert.fail("Could not install Central content from " + System.getProperty("org.jboss.tools.central.discovery") + "\n" + reason);


### PR DESCRIPTION
Installation test from Central are failing because of timeout on JBoss Jenkins.
So I increased timeout.
