### PR TITLE
JBIDE-12592: El is not revalidated in java comments

### DIFF
--- a/common/plugins/org.jboss.tools.common.validation/src/org/jboss/tools/common/validation/TempMarkerManager.java
+++ b/common/plugins/org.jboss.tools.common.validation/src/org/jboss/tools/common/validation/TempMarkerManager.java
@@ -28,6 +28,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
@@ -227,6 +228,7 @@ abstract public class TempMarkerManager extends ValidationErrorManager {
 		return message;
 	}
 
+	@Deprecated // Probably a useful class, but not used at the moment 
 	private static class SimpleReference implements ITextSourceReference {
 		int start;
 		int length;
@@ -254,13 +256,12 @@ abstract public class TempMarkerManager extends ValidationErrorManager {
 		}
 	};
 
-	protected void disableProblemAnnotations(ITextSourceReference region, IReporter reporter) {
+	protected void disableProblemAnnotations(final IRegion region, IReporter reporter) {
 		List messages = reporter.getMessages();
 		IMessage[] msgs = EMPTY_MESSAGE_ARRAY;
 		if(messages!=null) {
 			msgs = (IMessage[])messages.toArray(new IMessage[messages.size()]);
 		}
-		final ITextSourceReference reference = new SimpleReference(region.getStartPosition(), region.getLength(), region.getResource());
 
 		final IMessage[] messageArray = msgs;
         UIJob job = new UIJob("As-you-type JBT validation. Disabling the marker annotations.") {
@@ -274,7 +275,7 @@ abstract public class TempMarkerManager extends ValidationErrorManager {
 						if(model instanceof AbstractMarkerAnnotationModel) {
 							AbstractMarkerAnnotationModel anModel = ((AbstractMarkerAnnotationModel)model);
 							synchronized (anModel.getLockObject()) {
-								Iterator iterator = anModel.getAnnotationIterator(reference.getStartPosition(), reference.getLength(), true, true);
+								Iterator iterator = anModel.getAnnotationIterator(region.getOffset(), region.getLength(), true, true);
 								Set<Annotation> annotationsToRemove = new HashSet<Annotation>();
 								Map<Annotation, Position> newAnnotations = new HashMap<Annotation, Position>();
 								while (iterator.hasNext()) {

--- a/common/plugins/org.jboss.tools.common.validation/src/org/jboss/tools/common/validation/java/JavaDirtyRegionProcessor.java
+++ b/common/plugins/org.jboss.tools.common.validation/src/org/jboss/tools/common/validation/java/JavaDirtyRegionProcessor.java
@@ -210,12 +210,12 @@ final public class JavaDirtyRegionProcessor extends
 					ValidationMessage valMessage = (ValidationMessage)m;
 					if (position != null && position.getOffset() == valMessage.getOffset() && position.getLength() == valMessage.getLength()) {
 						String text = valMessage.getText();
-						text = text == null ? "" : text;
+						text = text == null ? "" : text; //$NON-NLS-1$
 						if (!text.equalsIgnoreCase(jpAnnotation.getText()))
 							continue;
 						
 						Object type = valMessage.getAttribute(TempMarkerManager.MESSAGE_TYPE_ATTRIBUTE_NAME);
-						type = type == null ? "" : type;
+						type = type == null ? "" : type; //$NON-NLS-1$
 						Map jpAttributes = jpAnnotation.getAttributes();
 						if (jpAttributes == null)
 							continue;
@@ -473,10 +473,13 @@ final public class JavaDirtyRegionProcessor extends
 		fEndPartitionsToProcess = (fEndPartitionsToProcess == -1 || fEndPartitionsToProcess < end) ? end : fEndPartitionsToProcess;
 
 		ITypedRegion[] partitions = computePartitioning(start, end - start);
-
 		for (ITypedRegion partition : partitions) {
 			if (partition != null && !fIsCanceled) {
-				if (IJavaPartitions.JAVA_STRING.equals(partition.getType()) && !fPartitionsToProcess.contains(partition)) {
+				String type = partition.getType();
+				if ((IJavaPartitions.JAVA_STRING.equals(type) || IJavaPartitions.JAVA_CHARACTER.equals(type) ||
+						IJavaPartitions.JAVA_SINGLE_LINE_COMMENT.equals(type) || 
+						IJavaPartitions.JAVA_MULTI_LINE_COMMENT.equals(type) || IJavaPartitions.JAVA_DOC.equals(type)) 
+						&& !fPartitionsToProcess.contains(partition)) {
 					fPartitionsToProcess.add(partition);
 				}
 			}
@@ -560,7 +563,7 @@ final public class JavaDirtyRegionProcessor extends
 					if (position >= range.getOffset()) {
 						try {
 							String text = fDocument.get(range.getOffset(), position - range.getOffset() + 1); 
-							if (text.indexOf('{') != -1 && !text.endsWith("}")) {
+							if (text.indexOf('{') != -1 && !text.endsWith("}")) { //$NON-NLS-1$
 								doSkipThisElement = true;
 								position = range.getOffset() + range.getLength();
 							}


### PR DESCRIPTION
JavaDirtyRegionProcessor is made to watch and validate when an EL in a Java Comment is changed
