### PR TITLE
JBIDE-13344 - DirtyRegionProcessor.BackgroundThread unnecessarily create...

### DIFF
--- a/common/plugins/org.jboss.tools.common.validation/src/org/jboss/tools/common/validation/java/xpl/DirtyRegionProcessor.java
+++ b/common/plugins/org.jboss.tools.common.validation/src/org/jboss/tools/common/validation/java/xpl/DirtyRegionProcessor.java
@@ -526,6 +526,9 @@ public class DirtyRegionProcessor implements IReconciler, IReconcilerExtension, 
 	 */
 	private synchronized DirtyRegion[] getRequests() {
 		synchronized (fDirtyRegionQueue) {
+			if (0 == fDirtyRegionQueue.size()) {
+				return null;
+			}
 			DirtyRegion[] toRefresh = (DirtyRegion[]) fDirtyRegionQueue.toArray(new DirtyRegion[fDirtyRegionQueue.size()]);
 			flushDirtyRegionQueue();
 			return toRefresh;
@@ -683,15 +686,15 @@ public class DirtyRegionProcessor implements IReconciler, IReconcilerExtension, 
 				boolean processed = false;
 				try {
 					DirtyRegion[] toRefresh = getRequests();
-					if (toRefresh.length > 0) {
+					if (toRefresh != null && toRefresh.length > 0) {
 						processed = true;
 						beginProcessing();
-					}
 	
-					for (int i = 0; i < toRefresh.length && fDocument != null; i++) {
-						if (fIsCanceled)
-							return;
-						process(toRefresh[i]);
+						for (int i = 0; i < toRefresh.length && fDocument != null; i++) {
+							if (fIsCanceled)
+								return;
+							process(toRefresh[i]);
+						}
 					}
 				}
 				finally {


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-13344
DirtyRegionProcessor.BackgroundThread unnecessarily creates a lot of DirtyRegion[] objects
