### PR TITLE
JBIDE-13844 JarAccess should ignore .class entries in jar files

### DIFF
--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/JarAccess.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/JarAccess.java
@@ -118,6 +118,10 @@ public class JarAccess {
 			while(en.hasMoreElements()) {
 					ZipEntry entry = (ZipEntry)en.nextElement();
 					String name = entry.getName();
+					if(name != null && name.endsWith(".class")) {
+						//Ignore .class entries. They are handled by JDT.
+						continue;
+					}
 					if(name != null && !name.endsWith(XModelObjectConstants.SEPARATOR) && entry.getSize() > 0) {
 						fileEntries.put(name, Long.valueOf(entry.getSize()));
 					}


### PR DESCRIPTION
Merge to jbosstools-4.0.x.
