### PR TITLE
JBIDE-13911 - testUnzipOperationExecuteStringString() always fails on Windows

### DIFF
--- a/common/plugins/org.jboss.tools.common.core/src/org/jboss/tools/common/zip/UnzipOperation.java
+++ b/common/plugins/org.jboss.tools.common.core/src/org/jboss/tools/common/zip/UnzipOperation.java
@@ -47,7 +47,7 @@ public class UnzipOperation {
 	}
 	
 	public void execute(String destination,String filter) throws IOException {
-		execute(new File(destination,filter));
+		execute(new File(destination), filter);
 	}
 	
 	public static class FilteredZipEntryVisitor implements IZipEntryVisitor{


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-13911
org.jboss.tools.common.zip.test.UnzipOperationTest.testUnzipOperationExecuteStringString() always fails on Windows
