### PR TITLE
JBIDE-13939 - Usage tests freeze on Kepler M6

### DIFF
--- a/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/reporting/UsageReportDispatcher.java
+++ b/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/reporting/UsageReportDispatcher.java
@@ -13,6 +13,7 @@ package org.jboss.tools.usage.internal.reporting;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IStartup;
 import org.jboss.tools.usage.internal.JBossToolsUsageActivator;
+import org.jboss.tools.usage.internal.preferences.GlobalUsageSettings;
 import org.jboss.tools.usage.tracker.internal.UsagePluginLogger;
 
 /**
@@ -21,6 +22,10 @@ import org.jboss.tools.usage.tracker.internal.UsagePluginLogger;
 public class UsageReportDispatcher implements IStartup {
 
 	public void earlyStartup() {
+		String enabled = System.getProperty(GlobalUsageSettings.USAGE_REPORTING_ENABLED_KEY);
+		if ("false".equals(enabled)) {
+			return;
+		}
 		Display.getDefault().asyncExec(new Runnable() {
 
 			public void run() {


### PR DESCRIPTION
The PR fixes the issue even if Eclipse changes the way in which the UI
Synchronizer runs UI messages.

Eclipse < Kepler M6 calls UI messages before running tests, Eclipse
Kepler M6 on Linux calls them after running tests.
See http://lists.jboss.org/pipermail/jbosstools-dev/2013-April/007422.html
Such behaviour isn't a bug. An asynchronous UI message can be run in any time.
This means, Eclipse can change this behavior and run an UI message during running tests.
In this case neither https://github.com/jbosstools/jbosstools-base/pull/75 nor https://github.com/jbosstools/jbosstools-base/pull/76 will help.

However, the org.eclipse.ui.startup ext. points must be executed before starting any other functionalities in Eclipse. Otherwise,  the Eclipse API would be broken which would be a bug in Eclipse.

The PR checks the flag within the usage's startup ext. point and, if it is set to false, doesn't try to start the dialog. The PR will solve the issue no matter what tests do or don't do.

Eclipse will run tests as follows:
- the usage_reporting_enabled property is set to false in the parent pom  (or from the commandline, in PDE ...)
- Eclipse starts the usage extension point, but since usage_reporting_enabled=false, the ext. point won't trigger opening the dialog
- Eclipse runs tests

Such behaviour can't be changed without changing the Eclipse API.
