### PR TITLE
JBIDE-13943 Java Model Exception when CDI component name is modified

### DIFF
--- a/common/plugins/org.jboss.tools.common.core/src/org/jboss/tools/common/util/EclipseJavaUtil.java
+++ b/common/plugins/org.jboss.tools.common.core/src/org/jboss/tools/common/util/EclipseJavaUtil.java
@@ -97,7 +97,7 @@ public class EclipseJavaUtil {
 	 * @throws JavaModelException
 	 */
 	public static IType findType(IJavaProject javaProject, String qualifiedName) throws JavaModelException {
-		if(qualifiedName == null || qualifiedName.length() == 0) return null;
+		if(qualifiedName == null || qualifiedName.length() == 0 || "void".equals(qualifiedName)) return null;
 		Map<String, IType> cache = typeCache.get(javaProject.getElementName());
 		if(cache == null) {
 			cache = new Hashtable<String, IType>();
@@ -107,7 +107,7 @@ public class EclipseJavaUtil {
 			if(type != null) return type;
 		}
 		IType type = javaProject.findType(qualifiedName);
-		if(type != null) return register(cache, qualifiedName, type);
+		if(type != null && type.exists()) return register(cache, qualifiedName, type);
 
 		//TODO Either provide use-case that justifies the 
 		//     direct search over roots when IJavaProject.findType(String) fails

--- a/common/tests/org.jboss.tools.common.model.test/projects/Test1/src/demo/A.java
+++ b/common/tests/org.jboss.tools.common.model.test/projects/Test1/src/demo/A.java
@@ -1,0 +1,5 @@
+package demo;
+
+class B {
+
+}

--- a/common/tests/org.jboss.tools.common.model.test/src/org/jboss/tools/common/model/util/test/EclipseJavaUtilTest.java
+++ b/common/tests/org.jboss.tools.common.model.test/src/org/jboss/tools/common/model/util/test/EclipseJavaUtilTest.java
@@ -42,6 +42,15 @@ public class EclipseJavaUtilTest extends TestCase {
 		JobUtils.waitForIdle();
 	}
 
+	public void testFindClass() throws Exception {
+		IJavaProject jp = EclipseResourceUtil.getJavaProject(project1);
+		IType t = jp.findType("demo.A");
+		assertNotNull(t);
+		assertFalse(t.exists());
+		t = EclipseJavaUtil.findType(jp, "demo.A");
+		assertNull(t);
+	}
+
 	public void testGetters() throws Exception {
 		IJavaProject jp = EclipseResourceUtil.getJavaProject(project1);
 		assertNotNull(jp);


### PR DESCRIPTION
EclipseJavaUtil.findType should return only existing types.
