### PR TITLE
JBIDE-13995 EL suggestions box options depends on order of methods

### DIFF
--- a/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/ca/AbstractELCompletionEngine.java
+++ b/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/ca/AbstractELCompletionEngine.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2007-2011 Red Hat, Inc. 
+ * Copyright (c) 2007-2013 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -386,7 +386,7 @@ public abstract class AbstractELCompletionEngine<V extends IVariable> implements
 					if (sourceTypeName != null && sourceTypeName.indexOf('.') != -1) {
 						sourceTypeName = Signature.getSimpleName(sourceTypeName);
 					}
-					String typeName = memberInfo == null ? null : memberInfo.getType().getName();
+					String typeName = memberInfo == null ? null : memberInfo.getMemberTypeName();
 					if (typeName != null && typeName.indexOf('.') != -1) { 
 						typeName = Signature.getSimpleName(typeName);
 					}
@@ -509,7 +509,7 @@ public abstract class AbstractELCompletionEngine<V extends IVariable> implements
 					String sourceTypeName = member == null ? null : member.getDeclaringTypeQualifiedName();
 					if (sourceTypeName != null && sourceTypeName.indexOf('.') != -1) 
 						sourceTypeName = Signature.getSimpleName(sourceTypeName);
-					String typeName = member == null ? null : member.getType().getName();
+					String typeName = member == null ? null : member.getMemberTypeName();
 					if (typeName != null && typeName.indexOf('.') != -1) 
 						typeName = Signature.getSimpleName(typeName);
 
@@ -563,7 +563,7 @@ public abstract class AbstractELCompletionEngine<V extends IVariable> implements
 				String sourceTypeName = member == null ? null : member.getDeclaringTypeQualifiedName();
 				if (sourceTypeName != null && sourceTypeName.indexOf('.') != -1) 
 					sourceTypeName = Signature.getSimpleName(sourceTypeName);
-				String typeName = member == null ? null : member.getType().getName();
+				String typeName = member == null ? null : member.getMemberTypeName();
 				if (typeName != null && typeName.indexOf('.') != -1) 
 					typeName = Signature.getSimpleName(typeName);
 					
@@ -878,7 +878,7 @@ public abstract class AbstractELCompletionEngine<V extends IVariable> implements
 						String sourceTypeName = member == null ? null : member.getDeclaringTypeQualifiedName();
 						if (sourceTypeName != null && sourceTypeName.indexOf('.') != -1) 
 							sourceTypeName = Signature.getSimpleName(sourceTypeName);
-						String typeName = member == null ? null : member.getType().getName();
+						String typeName = member == null ? null : member.getMemberTypeName();
 						if (typeName != null && typeName.indexOf('.') != -1) 
 							typeName = Signature.getSimpleName(typeName);
 
@@ -924,7 +924,7 @@ public abstract class AbstractELCompletionEngine<V extends IVariable> implements
 						String sourceTypeName = member == null ? null : member.getDeclaringTypeQualifiedName();
 						if (sourceTypeName != null && sourceTypeName.indexOf('.') != -1) 
 							sourceTypeName = Signature.getSimpleName(sourceTypeName);
-						String typeName = member == null ? null : member.getType().getName();
+						String typeName = member == null ? null : member.getMemberTypeName();
 						if (typeName != null && typeName.indexOf('.') != -1) 
 							typeName = Signature.getSimpleName(typeName);
 
@@ -1029,7 +1029,7 @@ public abstract class AbstractELCompletionEngine<V extends IVariable> implements
 					String sourceTypeName = member == null ? null : member.getDeclaringTypeQualifiedName();
 					if (sourceTypeName != null && sourceTypeName.indexOf('.') != -1) 
 						sourceTypeName = Signature.getSimpleName(sourceTypeName);
-					String typeName = member == null ? null : member.getType().getName();
+					String typeName = member == null ? null : member.getMemberTypeName();
 					if (typeName != null && typeName.indexOf('.') != -1) 
 						typeName = Signature.getSimpleName(typeName);
 

--- a/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/TypeInfoCollector.java
+++ b/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/TypeInfoCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007-2011 Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -41,7 +41,7 @@ import org.jboss.tools.common.util.EclipseJavaUtil;
 
 /**
  * This class helps to collect information of java elements used in Seam EL.
- * @author Viktor Rubezhny, Alexey Kazakov
+ * @author Victor Rubezhny, Alexey Kazakov
  */
 public class TypeInfoCollector {
 	IType fType;
@@ -255,6 +255,17 @@ public class TypeInfoCollector {
 			return fType;
 		}
 
+		/**
+		 * Returns the name of member type. In most cases it will return the result of call to fType.getName().
+		 * The only exclusion is the MethodInfo that is a Property Setter (isSetter() == true):
+		 * 	- In case of a Setter Method it should return the name of the setter parameter value type
+		 * 
+		 * @return
+		 */
+		public String getMemberTypeName() {
+			return fType.getName();
+		}
+		
 		public void setSourceType(IType sourceType) {
 			fSourceType = sourceType;
 		}
@@ -702,6 +713,14 @@ public class TypeInfoCollector {
 			name.append(')');
 			list.add(name.toString());
 			return list;
+		}
+		
+		@Override
+		public String getMemberTypeName() {
+			if (isSetter()) {
+				return getParameterTypeNames()[0];
+			}
+			return super.getMemberTypeName();
 		}
 
 		@Override

--- a/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/ca/ELProposalProcessor.java
+++ b/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/ca/ELProposalProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007-2012 Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -82,12 +82,21 @@ import org.w3c.dom.Text;
  * Content assist proposal processor.
  * Computes Seam EL proposals.
  * 
- * @author Jeremy
+ * @author Victor Rubezhny
  */
 public abstract class ELProposalProcessor extends AbstractContentAssistProcessor {
 
 	private static final ICompletionProposal[] NO_PROPOSALS= new ICompletionProposal[0];
 	private static final IContextInformation[] NO_CONTEXTS= new IContextInformation[0];
+	
+	/*
+	 * Sorts IJavaElements by IJavaElement.getElementName() case insensitive order
+	 */
+    public static final Comparator<IJavaElement> CASE_INSENSITIVE_ORDER = new Comparator<IJavaElement>() {
+		public int compare(IJavaElement o1, IJavaElement o2) {
+			return String.CASE_INSENSITIVE_ORDER.compare(o1.getElementName() , o2.getElementName());
+		}	
+	};
 
 	public static final class Proposal implements ICompletionProposal, ICompletionProposalExtension, ICompletionProposalExtension2, ICompletionProposalExtension3, ICompletionProposalExtension4, IRelevanceCompletionProposal {
 
@@ -156,6 +165,7 @@ public abstract class ELProposalProcessor extends AbstractContentAssistProcessor
 		public String getAdditionalProposalInfo() {
 			if (fAdditionalProposalInfo == null) {
 				if (this.fJavaElements != null && this.fJavaElements.length > 0) {
+					Arrays.sort(this.fJavaElements, ELProposalProcessor.CASE_INSENSITIVE_ORDER);
 					this.fAdditionalProposalInfo = extractProposalContextInfo(fJavaElements);
 				} else if (fPropertySource != null) {
 					this.fAdditionalProposalInfo = extractProposalContextInfo(fPropertySource);


### PR DESCRIPTION
The issue is fixed by the sorting of getters and setters and using an argument type as a property type in case
of setter is set as a first or the only one IJavaElement for the property.
The getters and setters are set to appear sorted in Content Assistatn additional info window as well as in EL Tooltips for
Java/HTML/JSP/XHTML Editors.
JUnit Test is added for the issue: org.jboss.tools.jsf.jsp.ca.test.CAELBeanPropertyTest.
Existing org.jboss.tools.jsf.jsp.hover.ELTooltipTest JUnit Test is updated as well due to test the issue.

```
modified:   common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/ca/AbstractELCompletionEngine.java
modified:   common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/TypeInfoCollector.java
modified:   common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/ca/ELProposalProcessor.java
```
