### PR TITLE
JBIDE-14095 Full path to the opened file instead of a workspace related path

### DIFF
--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/core/resources/XModelObjectEditorInput.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/core/resources/XModelObjectEditorInput.java
@@ -109,7 +109,7 @@ public class XModelObjectEditorInput extends FileEditorInput implements IModelOb
 
 	public String getToolTipText() {
 		IFile f = (IFile)EclipseResourceUtil.getResource(object);
-		if(f != null && f.exists()) return f.getLocation().toString();
+		if(f != null && f.exists()) return f.getFullPath().makeRelative().toString();
 		return object.getPresentationString();
 	}
 


### PR DESCRIPTION
XModelObjectEditorInput.getToolTipText() is modified
to return for a file the same result as FileEditorInput.
