### PR TITLE
JBIDE-14412 jQuery Mobile wizards do not show descriptions

### DIFF
--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/editors/dnd/DefaultDropWizardPage.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/editors/dnd/DefaultDropWizardPage.java
@@ -63,7 +63,7 @@ public abstract class DefaultDropWizardPage extends WizardPage {
 		try {
 			validate();
 			setPageComplete(true);
-			setMessage("",NONE);				 //$NON-NLS-1$
+			setMessage(null, NONE);
 		} catch (ValidationException e) {
 			validationErrorOccurs(e);
 			setPageComplete(false);


### PR DESCRIPTION
Prevented overriding wizard description by empty message.
