### PR TITLE
JBIDE-14515 cdi.ui tests failure

### DIFF
--- a/common/plugins/org.jboss.tools.common.validation/plugin.xml
+++ b/common/plugins/org.jboss.tools.common.validation/plugin.xml
@@ -4,8 +4,6 @@
    <extension-point id="validator" name="KB Validator" schema="schema/validator.exsd"/>
    <extension-point id="warnings" name="Warning names supported by @SuppressWarnings" schema="schema/warnings.exsd"/>
  
-   <extension point="org.eclipse.ui.startup" />
- 
    <extension
         point="org.eclipse.wst.validation.validator"
 		id="cd"

--- a/common/tests/org.jboss.tools.common.base.test/src/org/jboss/tools/common/base/test/validation/java/BaseAsYouTypeInJavaValidationTest.java
+++ b/common/tests/org.jboss.tools.common.base.test/src/org/jboss/tools/common/base/test/validation/java/BaseAsYouTypeInJavaValidationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 Red Hat, Inc.
+ * Copyright (c) 2012-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -23,6 +23,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.texteditor.MarkerAnnotation;
 import org.jboss.tools.common.base.test.validation.AbstractAsYouTypeValidationTest;
+import org.jboss.tools.common.validation.CommonValidationPlugin;
 import org.jboss.tools.tests.AbstractResourceMarkerTest;
 
 /**
@@ -39,9 +40,13 @@ public class BaseAsYouTypeInJavaValidationTest extends AbstractAsYouTypeValidati
 	public BaseAsYouTypeInJavaValidationTest(IProject project, String resourceMarkerType) {
 		this.project = project;
 		this.fResourceMarkerType = resourceMarkerType;
+		CommonValidationPlugin.getDefault().earlyStartup(); // JBIDE-14515 - We need it here because of 
+															// no early startup code is called under Tycho
 	}
 	public BaseAsYouTypeInJavaValidationTest() {
 		this.fResourceMarkerType = RESOURCE_MARKER_TYPE;
+		CommonValidationPlugin.getDefault().earlyStartup(); // JBIDE-14515 - We need it here because of 
+															// no early startup code is called under Tycho
 	}
 	
 	@Override

--- a/tests/plugins/org.jboss.tools.tests/src/org/jboss/tools/test/util/JobUtils.java
+++ b/tests/plugins/org.jboss.tools.tests/src/org/jboss/tools/test/util/JobUtils.java
@@ -39,15 +39,39 @@ public class JobUtils {
 				Job[] jobs = Job.getJobManager().find(null);
 				StringBuffer str = new StringBuffer();
 				for (Job job : jobs) {
-					if (job.getThread() != null) {
+					if (job.getThread() != null && !shouldIgnoreJob(job)) {
 						str.append("\n").append(job.getName()).append(" (")
 								.append(job.getClass()).append(")");
 					}
 				}
-				throw new RuntimeException(
-						"Long running tasks detected:" + str.toString()); //$NON-NLS-1$
+				if (str.length() > 0)
+					throw new RuntimeException(
+							"Long running tasks detected:" + str.toString()); //$NON-NLS-1$
 			}
 		}
+	}
+
+	// The list of non-build related long running jobs
+	private static final String[] IGNORE_JOBS_NAMES = new String[] {
+		"workbench auto-save job"
+	};
+	
+	/**
+	 * A workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=405456 in Eclipse 4.3.0M7
+	 * (since -Dorg.eclipse.ui.testsDisableWorkbenchAutoSave=true option is not yet implemented in M7)
+	 *
+	 * @param job
+	 * @return
+	 */
+	private static boolean shouldIgnoreJob(Job job) {
+		for (String name : IGNORE_JOBS_NAMES) {
+			if (name != null && job != null && job.getName() != null && 
+					name.equalsIgnoreCase(job.getName().trim())) {
+				System.out.println("Ignoring the non-build long running job: " + job.getName());
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public static void delay(long waitTimeMillis) {


### PR DESCRIPTION
JobUtils.waitForIdle(...) timeout issue is fixed.
Wrong startup definition that caused NoSuchMethodException to be logged is excluded from org.jboss.tools.common.validation/plugin.xml
Explicit JavaEditorTracker initialization is added for the tests due to fix the issue
AbstractAsYouTypeValidationTest.waitForAnnotation() runnable is fixed to let other than Display Thread to process while waiting for annotation.
