### PR TITLE
[JBIDE-15256] Include source gen plugin for features into pluginManagement

### DIFF
--- a/common/features/org.jboss.tools.common.all.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.all.feature/pom.xml
@@ -9,37 +9,4 @@
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.all.feature</artifactId> 
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/common/features/org.jboss.tools.common.all.test.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.all.test.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.all.test.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/common/features/org.jboss.tools.common.core.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.core.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.core.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/common/features/org.jboss.tools.common.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/common/features/org.jboss.tools.common.jdt.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.jdt.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.jdt.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/common/features/org.jboss.tools.common.mylyn.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.mylyn.feature/pom.xml
@@ -8,45 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.mylyn.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<excludes>
-						<!-- <plugin id="sourceplugin.nosource"/> -->
-			                	<!-- <feature id="sourcefeature.feature.nosource"/> -->
-    				</excludes>
-                </configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/common/features/org.jboss.tools.common.text.ext.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.text.ext.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.text.ext.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/common/features/org.jboss.tools.common.ui.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.ui.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.ui.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/common/features/org.jboss.tools.common.verification.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.verification.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.verification.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/common/features/pom.xml
+++ b/common/features/pom.xml
@@ -4,7 +4,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<groupId>org.jboss.tools.common</groupId>
 	<artifactId>features</artifactId>
 	<name>common.features</name>
-
 	<parent>	
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>common</artifactId>
@@ -22,5 +21,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<module>org.jboss.tools.common.jdt.feature</module>
 		<module>org.jboss.tools.common.mylyn.feature</module>
 	</modules>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-source-feature-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>
 	

--- a/foundation/features/org.jboss.tools.foundation.feature/pom.xml
+++ b/foundation/features/org.jboss.tools.foundation.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.foundation.features</groupId>
 	<artifactId>org.jboss.tools.foundation.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/foundation/features/org.jboss.tools.foundation.security.linux.feature/pom.xml
+++ b/foundation/features/org.jboss.tools.foundation.security.linux.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.foundation.features</groupId>
 	<artifactId>org.jboss.tools.foundation.security.linux.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/foundation/features/org.jboss.tools.foundation.test.feature/pom.xml
+++ b/foundation/features/org.jboss.tools.foundation.test.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.foundation.test.features</groupId>
 	<artifactId>org.jboss.tools.foundation.test.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/foundation/features/pom.xml
+++ b/foundation/features/pom.xml
@@ -4,7 +4,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<groupId>org.jboss.tools.foundation</groupId>
 	<artifactId>features</artifactId>
 	<name>foundation.features</name>
-
 	<parent>	
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>foundation</artifactId>
@@ -16,5 +15,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<module>org.jboss.tools.foundation.security.linux.feature</module>
 		<module>org.jboss.tools.foundation.test.feature</module>
 	</modules>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-source-feature-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>
 	

--- a/runtime/features/org.jboss.tools.runtime.core.feature/pom.xml
+++ b/runtime/features/org.jboss.tools.runtime.core.feature/pom.xml
@@ -9,39 +9,5 @@
 	</parent>
 	<groupId>org.jboss.tools.runtime.features</groupId>
 	<artifactId>org.jboss.tools.runtime.core.feature</artifactId>
-	
 	<packaging>eclipse-feature</packaging>
-	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/runtime/features/org.jboss.tools.runtime.test.feature/pom.xml
+++ b/runtime/features/org.jboss.tools.runtime.test.feature/pom.xml
@@ -9,39 +9,5 @@
 	</parent>
 	<groupId>org.jboss.tools.runtime.features</groupId>
 	<artifactId>org.jboss.tools.runtime.test.feature</artifactId>
-	
 	<packaging>eclipse-feature</packaging>
-	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/runtime/features/pom.xml
+++ b/runtime/features/pom.xml
@@ -9,11 +9,22 @@
 	</parent>
 	<groupId>org.jboss.tools.runtime</groupId>
 	<artifactId>features</artifactId>
-	
 	<name>runtime.features</name>
 	<packaging>pom</packaging>
 	<modules>
 		<module>org.jboss.tools.runtime.core.feature</module>
 		<module>org.jboss.tools.runtime.test.feature</module>
 	</modules>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-source-feature-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/stacks/features/org.jboss.tools.stacks.core.feature/pom.xml
+++ b/stacks/features/org.jboss.tools.stacks.core.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.stacks.features</groupId>
 	<artifactId>org.jboss.tools.stacks.core.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/stacks/features/org.jboss.tools.stacks.core.test.feature/pom.xml
+++ b/stacks/features/org.jboss.tools.stacks.core.test.feature/pom.xml
@@ -8,39 +8,5 @@
 	</parent>
 	<groupId>org.jboss.tools.stacks.features</groupId>
 	<artifactId>org.jboss.tools.stacks.core.test.feature</artifactId> 
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/stacks/features/pom.xml
+++ b/stacks/features/pom.xml
@@ -4,7 +4,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<groupId>org.jboss.tools.stacks</groupId>
 	<artifactId>features</artifactId>
 	<name>stacks.features</name>
-
 	<parent>	
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>stacks</artifactId>
@@ -15,5 +14,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<module>org.jboss.tools.stacks.core.feature</module>
 		<module>org.jboss.tools.stacks.core.test.feature</module>
 	</modules>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-source-feature-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>	
 </project>
 	

--- a/tests/features/org.jboss.tools.test.feature/pom.xml
+++ b/tests/features/org.jboss.tools.test.feature/pom.xml
@@ -9,37 +9,4 @@
 	<groupId>org.jboss.tools.tests.features</groupId>
 	<artifactId>org.jboss.tools.test.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/tests/features/pom.xml
+++ b/tests/features/pom.xml
@@ -14,4 +14,17 @@
 	<modules>
 		<module>org.jboss.tools.test.feature</module>
 	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-source-feature-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/usage/features/org.jboss.tools.usage.feature/pom.xml
+++ b/usage/features/org.jboss.tools.usage.feature/pom.xml
@@ -10,39 +10,5 @@
 	<groupId>org.jboss.tools.usage.features</groupId>
 	<artifactId>org.jboss.tools.usage.feature</artifactId>
 	<name>org.jboss.tools.usage.feature</name>
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/usage/features/org.jboss.tools.usage.test.feature/pom.xml
+++ b/usage/features/org.jboss.tools.usage.test.feature/pom.xml
@@ -10,39 +10,5 @@
 	<groupId>org.jboss.tools.usage.features</groupId>
 	<artifactId>org.jboss.tools.usage.test.feature</artifactId>
 	<name>org.jboss.tools.usage.test.feature</name>
-	
 	<packaging>eclipse-feature</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tychoExtrasVersion}</version>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tychoVersion}</version>
-				<executions>
-					<execution>
-						<id>attached-p2-metadata</id>
-						<phase>package</phase>
-						<goals>
-							<goal>p2-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/usage/features/pom.xml
+++ b/usage/features/pom.xml
@@ -12,9 +12,23 @@
 	
 	<name>usage.features</name>	
 	<packaging>pom</packaging>
+
 	<modules>
 		<module>org.jboss.tools.usage.feature</module>
 		<module>org.jboss.tools.usage.test.feature</module>
 	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-source-feature-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>
 	


### PR DESCRIPTION
Source generation plugins moved to features/pom.xml and removed from 
features/feature-id/pom.xml files. This PR should be applied after 
https://github.com/jbosstools/jbosstools-build/pull/107 pushed to
jbosstools-build.
