### PR TITLE
[JBIDE-15280] Update parent/pom.xml version to 4.2.0.Alpha1

### DIFF
--- a/all-tests/pom.xml
+++ b/all-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.base</groupId>
 	<artifactId>all-tests</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>common</artifactId>

--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>foundation</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,20 +5,12 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0.CR1-SNAPSHOT</version>
+		<version>4.2.0.Alpha1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>base</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
-	 <!--
-		Note: building the update site for this component may require that you first build
-		the tycho plugins in ../build/tycho-plugins/, if they can't be resolved from Nexus.
-
-		mvn clean install
-			or
-		mvn clean install -B -U -fae -e -P jbosstools-nightly-staging-composite,jboss-requirements-composite-mirror,jboss-requirements-composite-extras-mirror,local.site -Dlocal.site=file:///home/nboldt/tmp/JBT_REPO_Juno/
-	-->
 	<modules>
 		<module>tests</module>
 		<module>foundation</module>
@@ -28,5 +20,19 @@
 		<module>usage</module>
 		<module>site</module>
 	</modules>
+	<repositories>
+		<!-- To resolve parent artifact -->
+		<repository>
+			<id>jboss-public-repository-group</id>
+			<name>JBoss Public Repository Group</name>
+			<url>http://repository.jboss.org/nexus/content/groups/public/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 </project>
 	

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>runtime</artifactId>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.base</groupId>
 	<artifactId>site</artifactId>

--- a/stacks/pom.xml
+++ b/stacks/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>stacks</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>tests</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>usage</artifactId>


### PR DESCRIPTION
updated parent pom version and added JBoss Public Group repo 
http://repository.jboss.org/nexus/content/groups/public which according to
https://community.jboss.org/wiki/MavenRepository has everything wee need to
build module out of the box without modification of ~/.m2/settings.xml

Bellt seems to be running with brand new local repo configured with
-Dmaven.repo.local=path/to/the/new/repository

Downloading:
http://repository.jboss.org/nexus/content/groups/public/org/jboss/tools/parent/4.2.0.Alpha1-SNAPSHOT/maven-metadata.xml 
Downloaded:
http://repository.jboss.org/nexus/content/groups/public/org/jboss/tools/parent/4.2.0.Alpha1-SNAPSHOT/maven-metadata.xml
(612 B at 2.1 KB/sec) Downloading:
http://repository.jboss.org/nexus/content/groups/public/org/jboss/tools/parent/4.2.0.Alpha1-SNAPSHOT/parent-4.2.0.Alpha1-20130718.151740-7.pom 
Downloaded:
http://repository.jboss.org/nexus/content/groups/public/org/jboss/tools/parent/4.2.0.Alpha1-SNAPSHOT/parent-4.2.0.Alpha1-20130718.151740-7.pom
(32 KB at 101.3 KB/sec)
