### PR TITLE
JBIDE-15327 CDI Test failure

### DIFF
--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/icons/impl/XModelObjectIcon.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/icons/impl/XModelObjectIcon.java
@@ -96,8 +96,8 @@ public class XModelObjectIcon {
 		Image ii = getIcon1(types);
 		if(ii != null) {
 			synchronized(registry) {
-				ModelPlugin.getDefault().getImageRegistry().remove(code);
-				ModelPlugin.getDefault().getImageRegistry().put(code, ii);
+				registry.remove(code);
+				registry.put(code, ii);
 			}
 		}
 		return ii;


### PR DESCRIPTION
In method XModelObjectIcon.getEclipseImage0(), code synchronized
by obtained registry instance, requests registry instance again,
but at initialization, this method does not guarantee the same
instance when requested from two threads concurrently.
