### PR TITLE
[JBIDE-15463] Increment version's service part for jbosstools-base/foundation submodule

### DIFF
--- a/foundation/features/org.jboss.tools.foundation.feature/feature.xml
+++ b/foundation/features/org.jboss.tools.foundation.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.foundation.feature"
       label="%featureName"
-      version="1.0.0.qualifier"
+      version="1.0.1.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.jboss.org/tools">

--- a/foundation/features/org.jboss.tools.foundation.feature/pom.xml
+++ b/foundation/features/org.jboss.tools.foundation.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.features</groupId>
 	<artifactId>org.jboss.tools.foundation.feature</artifactId> 

--- a/foundation/features/org.jboss.tools.foundation.security.linux.feature/feature.xml
+++ b/foundation/features/org.jboss.tools.foundation.security.linux.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.foundation.security.linux.feature"
       label="%featureName"
-      version="1.0.0.qualifier"
+      version="1.0.1.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.jboss.org/tools">

--- a/foundation/features/org.jboss.tools.foundation.security.linux.feature/pom.xml
+++ b/foundation/features/org.jboss.tools.foundation.security.linux.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.features</groupId>
 	<artifactId>org.jboss.tools.foundation.security.linux.feature</artifactId> 

--- a/foundation/features/org.jboss.tools.foundation.test.feature/feature.xml
+++ b/foundation/features/org.jboss.tools.foundation.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.foundation.test.feature"
       label="%featureName"
-      version="1.0.0.qualifier"
+      version="1.0.1.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.jboss.org/tools">

--- a/foundation/features/org.jboss.tools.foundation.test.feature/pom.xml
+++ b/foundation/features/org.jboss.tools.foundation.test.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.test.features</groupId>
 	<artifactId>org.jboss.tools.foundation.test.feature</artifactId> 

--- a/foundation/features/pom.xml
+++ b/foundation/features/pom.xml
@@ -8,7 +8,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>	
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>foundation</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<modules>

--- a/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.equinox.p2.core;bundle-version="2.2.0",
  org.eclipse.ecf.filetransfer;bundle-version="5.0.0",
  org.eclipse.ecf.provider.filetransfer;bundle-version="3.2.0",
  org.eclipse.ecf.provider.filetransfer.httpclient4;bundle-version="1.0.300"
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.plugins</groupId>
 	<artifactId>org.jboss.tools.foundation.core</artifactId> 

--- a/foundation/plugins/org.jboss.tools.foundation.security.linux/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.security.linux/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.jboss.tools.foundation.security.linux;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.equinox.security;bundle-version="1.1.100"
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/foundation/plugins/org.jboss.tools.foundation.security.linux/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.security.linux/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.plugins</groupId>
 	<artifactId>org.jboss.tools.foundation.security.linux</artifactId> 

--- a/foundation/plugins/pom.xml
+++ b/foundation/plugins/pom.xml
@@ -8,7 +8,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>	
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>foundation</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<modules>

--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>foundation</artifactId>
 	<name>foundation.all</name>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
 		<module>plugins</module>

--- a/foundation/tests/org.jboss.tools.foundation.core.test/META-INF/MANIFEST.MF
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.foundation.core.test;singleton:=true
 Bundle-Activator: org.jboss.tools.foundation.core.test.FoundationTestActivator
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.8.1",
  org.jboss.tools.foundation.core;bundle-version="1.0.0",

--- a/foundation/tests/org.jboss.tools.foundation.core.test/pom.xml
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.tests</groupId>
 	<artifactId>org.jboss.tools.foundation.core.test</artifactId>

--- a/foundation/tests/pom.xml
+++ b/foundation/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>foundation</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
jbosstools-base/foundation submodule had changes since 4.1.0.Final is released:

``` shell
$ git diff --name-only jbosstools-4.1.0.Final -- foundation 
foundation/plugins/org.jboss.tools.foundation.core/.options 
foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/Trace.java 
foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/ecf/internal/InternalURLTransport.java 
foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/ecf/internal/URLTransportCache.java 
foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/jobs/BarrierProgressWaitJob.java 
foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/jobs/BarrierWaitJob.java 
foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/jobs/InterruptableJoinJob.java 
foundation/pom.xml
```

No changes in Public API so far and hat means only service version should be incremented: 
1.0.0-SNAPSHOT => 1.0.1-SNAPSHOT
