### PR TITLE
TEIIDDES-1857: Creates a cross-platform file name validator

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Export-Package: org.jboss.tools.foundation.core;x-friends:="org.jboss.tools.foun
  org.jboss.tools.foundation.core.ecf,
  org.jboss.tools.foundation.core.jobs,
  org.jboss.tools.foundation.core.plugin,
- org.jboss.tools.foundation.core.plugin.log
+ org.jboss.tools.foundation.core.plugin.log,
+ org.jboss.tools.foundation.core.validate
 Require-Bundle: org.eclipse.equinox.p2.core;bundle-version="2.2.0",
  org.eclipse.equinox.security;bundle-version="1.1.100",
  org.eclipse.core.net;bundle-version="1.2.100",

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/FileNameValidator.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/FileNameValidator.java
@@ -1,0 +1,222 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.core.validate;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Validates a filename by creating a temporary file with the given name
+ * on the underlying filesystem. In addition, checks are made on reserved
+ * characters and words.
+ */
+public class FileNameValidator {
+
+    /**
+     * Not valid on Windows and make no sense to be included in a filename
+     */
+    public static final char[] RESERVED_CHARACTERS = {
+        '<', '>', ':' ,'"', '/', '\\', '|', '?', '*'
+    };
+
+    /**
+     * Root directory for testing files
+     */
+    private String parentDir = System.getProperty("java.io.tmpdir"); //$NON-NLS-1$
+
+    /**
+     * Message if the last call to {@link #validate(String)} failed.
+     * Overwritten by each call to {@link #validate(String)} and will
+     * be null if successful.
+     */
+    private String failMessage = null;
+
+    /**
+     * Flag to indicate whether the file name should be checked for a suffix
+     *
+     * False by default.
+     */
+    private boolean checkSuffix = false;
+
+    /**
+     * Collection of reserved characters that should not appear in filenames
+     */
+    private Collection<Character> reservedChars = new ArrayList<Character>();
+
+    /**
+     * Collection of reserved words that should not appear as filenames
+     */
+    private Collection<String> reservedWords = new ArrayList<String>();
+
+    /**
+     * Test whether the given file name contains any of the set of
+     * reserved characters
+     *
+     * @param fileName
+     *
+     * @return true if a reserved character is present, false otherwise.
+     */
+    private boolean containsReservedChars(String fileName) {
+        for (char c : RESERVED_CHARACTERS) {
+            if (fileName.indexOf(c) > -1)
+                return true;
+        }
+
+        for (char c : reservedChars) {
+            if (fileName.indexOf(c) > -1)
+                return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Tests whether the given filename is one of the reserved words
+     *
+     * @param fileName
+     * @return
+     */
+    private boolean isReservedWord(String fileName) {
+        for (String reservedWord : reservedWords) {
+            if (fileName.equalsIgnoreCase(reservedWord))
+                return true;
+
+            String[] nameComponents = fileName.split("\\."); //$NON-NLS-1$
+            for (String component : nameComponents) {
+                if (reservedWord.equalsIgnoreCase(component))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Test whether given file name contains a dot implying the presence
+     * of a suffix. This is important for Windows file names but not Unix.
+     *
+     * @param fileName
+     *
+     * @return true if a suffix is present or if this check has been disabled, false otherwise.
+     */
+    private boolean hasSuffix(String fileName) {
+        if (! checkSuffix) {
+            // check suffix disabled
+            return true;
+        }
+
+        return fileName.contains("."); //$NON-NLS-1$
+    }
+
+    /**
+     * Validate the given filename
+     *
+     * @param fileName
+     *
+     * @return true if the given filename is valid, false otherwise
+     */
+    public boolean validate(String fileName) {
+        failMessage = null;
+
+        if (fileName == null) {
+            failMessage = "The given file name is null"; //$NON-NLS-1$
+            return false;
+        }
+
+        if (containsReservedChars(fileName)) {
+            failMessage = "Contains reserved character"; //$NON-NLS-1$
+            return false;
+        }
+
+        if (isReservedWord(fileName)) {
+            failMessage = "Filename '" + fileName + "' is a reserved word"; //$NON-NLS-1$ //$NON-NLS-2$
+            return false;
+        }
+
+        if (! hasSuffix(fileName)) {
+            failMessage = "Filename lacks a suffix which is required in this environment"; //$NON-NLS-1$
+            return false;
+        }
+
+        File tempTestFile = new File(parentDir, fileName);
+        try {
+            if (tempTestFile.createNewFile()) {
+                tempTestFile.delete();
+                failMessage = null;
+                return true;
+            }
+        } catch (Exception ex) {
+          failMessage = ex.getLocalizedMessage();
+          return false;
+       }
+
+        return false;
+    }
+
+    /**
+     * Get the failure message if the last call to {@link #validate(String)} failed
+     * or null if successful.
+     *
+     * @return failure message or null
+     */
+    public String getFailureMessage() {
+        return failMessage;
+    }
+
+    /**
+     * Set the value of the check suffix option. If the check suffix flag is disabled
+     * then filenames that do NOT have a suffix will be considered valid.
+     *
+     * Filenames without a suffix are valid on Unix but not on Windows
+     *
+     * @param status
+     */
+    public void setCheckSuffix(boolean status) {
+        this.checkSuffix = status;
+    }
+
+    /**
+     * Set the parent directory which will be used in the filename validation.
+     * In most cases, the default of java's temporary directory should be
+     * sufficient but if the filename is going to be used on a different filesystem
+     * then in may be prudent to test on this alternative filesystem.
+     *
+     * @param directory
+     */
+    public void setParentDirectory(String directory) {
+        this.parentDir = directory;
+    }
+
+    /**
+     * Adds a character that should not be used in a filename.
+     *
+     * This character will be checked in addition to the minimum
+     * list detailed in RESERVER_CHARACTERS.
+     *
+     * @param character
+     */
+    public void addReservedCharacter(Character character) {
+        reservedChars.add(character);
+    }
+
+    /**
+     * Adds a word that should not be used as a filename.
+     *
+     * Once added, this word cannot appear as either a single filename or
+     * a filename with a suffix.
+     *
+     * @param reservedWord
+     */
+    public void addReservedWord(String reservedWord) {
+        reservedWords .add(reservedWord);
+    }
+}

--- a/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/test/validate/TestFileNameValidator.java
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/test/validate/TestFileNameValidator.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.core.test.validate;
+
+import junit.framework.TestCase;
+import org.jboss.tools.foundation.core.validate.FileNameValidator;
+import org.junit.Test;
+
+/**
+ * Test class for the {@link FileNameValidator}
+ */
+public class TestFileNameValidator extends TestCase {
+
+    /**
+     * Test validation of valid filenames
+     */
+    @Test
+    public void testValidateValidFileNames() {
+        String[] validFileNames = {
+            "test", "test345", "test-345", "test_345", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "test.xmi", "test.txt", "test.xml", "test.csv", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        };
+
+        FileNameValidator validator = new FileNameValidator();
+
+        for (String fileName : validFileNames) {
+            assertTrue(validator.validate(fileName));
+        }
+    }
+
+    /**
+     * Test the validation with the suffix check turned on
+     */
+    @Test
+    public void testValidateWithSuffixCheck() {
+        String[] validFileNames = {
+            "test", "test345", "test-345", "test_345", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        };
+
+        String[] validFileNamesWithSuffix = {
+            "test.xmi", "test.txt", "test.xml", "test.csv", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        };
+
+        FileNameValidator validator = new FileNameValidator();
+        validator.setCheckSuffix(true);
+
+        for (String fileName : validFileNames) {
+            assertFalse(validator.getFailureMessage(), validator.validate(fileName));
+        }
+
+        for (String fileName : validFileNamesWithSuffix) {
+            assertTrue(validator.validate(fileName));
+        }
+    }
+
+    /**
+     * Tests the validation of filenames using the built-in reserved characters
+     */
+    @Test
+    public void testValidateReservedCharacters() {
+        FileNameValidator validator = new FileNameValidator();
+
+        for (char c : FileNameValidator.RESERVED_CHARACTERS) {
+            StringBuilder builder = new StringBuilder("te"); //$NON-NLS-1$
+            builder.append(c);
+            builder.append("st"); //$NON-NLS-1$
+
+            assertFalse(validator.getFailureMessage(), validator.validate(builder.toString()));
+        }
+    }
+
+    /**
+     * Tests the loading and validation of added reserved characters
+     */
+    @Test
+    public void testValidateLoadedReservedCharacters() {
+        FileNameValidator validator = new FileNameValidator();
+
+        char[] reservedChars = new char[] {
+            ')', '(', '[', ']', '@', '~', '#'
+        };
+
+        for (char reservedChar : reservedChars) {
+            validator.addReservedCharacter(reservedChar);
+        }
+
+        for (char c : reservedChars) {
+            StringBuilder builder = new StringBuilder("te"); //$NON-NLS-1$
+            builder.append(c);
+            builder.append("st"); //$NON-NLS-1$
+
+            assertFalse(validator.getFailureMessage(), validator.validate(builder.toString()));
+        }
+    }
+
+    /**
+     * Tests the loading of reserved words and validation of them.
+     * All reserved words, whether singurlarly or with an extension,
+     * should fail the validator.
+     */
+    @Test
+    public void testValidateLoadedReservedWords() {
+        FileNameValidator validator = new FileNameValidator();
+
+        String[] reservedWords = new String[] {
+            "Select", "From", "TEMP", "SYS", "SYSADMIN" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+        };
+
+        for (String reservedWord : reservedWords) {
+            validator.addReservedWord(reservedWord);
+        }
+
+        for (String reservedWord : reservedWords) {
+            // Test the word
+            assertFalse(validator.getFailureMessage(), validator.validate(reservedWord));
+
+            // Test the word with a suffix
+            assertFalse(validator.getFailureMessage(), validator.validate(reservedWord + ".xmi")); //$NON-NLS-1$
+        }
+    }
+}


### PR DESCRIPTION
- FileNameValidator
  - Provides a single class that validates a file name against the underlying
    filesystem.
  - Single, centralised point for determining validity of file names.
  - Avoids trying to provide too many rules concerning known filesystems
    and OSs by using the file name to create a temporary file.
  - Provides set of options to enhance the validator such as ability to add
    other reserved characters, add reserved words and modify the directory
    where the temporary file test is conducted.
- Includes unit tests for validator
