### PR TITLE
TEIIDDES-1857: Creates a cross-platform file name validator

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
@@ -9,7 +9,9 @@ Export-Package: org.jboss.tools.foundation.core;x-friends:="org.jboss.tools.foun
  org.jboss.tools.foundation.core.ecf,
  org.jboss.tools.foundation.core.jobs,
  org.jboss.tools.foundation.core.plugin,
- org.jboss.tools.foundation.core.plugin.log
+ org.jboss.tools.foundation.core.plugin.log,
+ org.jboss.tools.foundation.core.validate,
+ org.jboss.tools.foundation.core.validate.impl;x-friends:="org.jboss.tools.foundation.core.test"
 Require-Bundle: org.eclipse.equinox.p2.core;bundle-version="2.2.0",
  org.eclipse.equinox.security;bundle-version="1.1.100",
  org.eclipse.core.net;bundle-version="1.2.100",

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/FileNameValidatorFactory.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/FileNameValidatorFactory.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.core.validate;
+
+import org.jboss.tools.foundation.core.validate.impl.FileNameValidator;
+
+/**
+ * Factory that provides an implementation of the {@link IFileNameValidator}
+ */
+public class FileNameValidatorFactory {
+
+    /**
+     * Create an instance of the default validator implementation
+     *
+     * @return instance of {@link IFileNameValidator}
+     */
+    public IFileNameValidator createValidator() {
+        return new FileNameValidator();
+    }
+}

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/IFileNameValidator.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/IFileNameValidator.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.core.validate;
+
+import org.eclipse.core.runtime.IStatus;
+
+/**
+ *
+ */
+public interface IFileNameValidator {
+
+    /**
+     * Null character
+     */
+    String NUL = "\u0000"; //$NON-NLS-1$
+
+    /**
+     * Dot character
+     */
+    String DOT = "."; //$NON-NLS-1$
+
+    /**
+     * Space character
+     */
+    String SPACE = " "; //$NON-NLS-1$
+
+    /**
+     * Characters not valid on any OS in a filename
+     */
+    char[] RESERVED_CHARACTERS = { '/' };
+
+    /**
+     * Characters not valid on Mac
+     */
+    char[] MAC_RESERVED_CHARACTERS = { ':' };
+
+    /**
+     * Characters not valid on Windows
+     */
+    char[] WIN_RESERVED_CHARACTERS = {
+        '<', '>', ':', '"', '\\', '|', '?', '*', '[', ']', '\u0001', '\u0002',
+        '\u0003', '\u0004', '\u0005', '\u0006', '\u0007', '\u0008', '\u0009', '\r', '\u000B', '\u000C', '\n', '\u000E', '\u000F',
+        '\u0010', '\u0011', '\u0012', '\u0013', '\u0014', '\u0015', '\u0016', '\u0017', '\u0018', '\u0019', '\u001A', '\u001B',
+        '\u001C', '\u001D', '\u001E', '\u001F', '\u007F'
+    };
+
+    /**
+     * Words that cannot be used as names of files on any OS
+     */
+    String[] RESERVED_WORDS = {DOT, DOT + DOT};
+
+    /**
+     * Words that cannot be used as names of files.
+     * Primarily, these are not allowed on Windows.
+     */
+    String[] WIN_RESERVED_WORDS = {
+        "CON", "PRN", //$NON-NLS-1$ //$NON-NLS-2$
+        "AUX", "CLOCK$", //$NON-NLS-1$ //$NON-NLS-2$
+        "NUL", "COM1", //$NON-NLS-1$ //$NON-NLS-2$
+        "COM2", "COM3", //$NON-NLS-1$ //$NON-NLS-2$
+        "COM4", "COM5", //$NON-NLS-1$ //$NON-NLS-2$
+        "COM6", "COM7", //$NON-NLS-1$ //$NON-NLS-2$
+        "COM8", "COM9", //$NON-NLS-1$ //$NON-NLS-2$
+        "LPT1", "LPT2", //$NON-NLS-1$ //$NON-NLS-2$
+        "LPT3", "LPT4", //$NON-NLS-1$ //$NON-NLS-2$
+        "LPT5", "LPT6", //$NON-NLS-1$ //$NON-NLS-2$
+        "LPT7", "LPT8", "LPT9" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    };
+
+    /**
+     * Validate the given filename
+     *
+     * @param fileName
+     *
+     * @return status indicating the result of the validity of the filename
+     */
+    IStatus validate(String fileName);
+
+    /**
+     * Set the parent directory which will be used in the filename validation.
+     * In most cases, the default of java's temporary directory should be
+     * sufficient but if the filename is going to be used on a different filesystem
+     * then in may be prudent to test on this alternative filesystem.
+     *
+     * @param directory
+     */
+    void setParentDirectory(String directory);
+
+    /**
+     * Adds a character that should not be used in a filename.
+     *
+     * This character will be checked in addition to the minimum
+     * list detailed in RESERVED_CHARACTERS.
+     *
+     * @param character
+     */
+    void addReservedCharacter(Character character);
+
+    /**
+     * Adds a word that should not be used as a filename.
+     *
+     * Once added, this word cannot appear as either a single filename or
+     * a filename with a suffix.
+     *
+     * @param reservedWord
+     */
+    void addReservedWord(String reservedWord);
+
+}

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/impl/FileNameValidator.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/impl/FileNameValidator.java
@@ -1,0 +1,412 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.core.validate.impl;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Status;
+import org.jboss.tools.foundation.core.FoundationCorePlugin;
+import org.jboss.tools.foundation.core.validate.IFileNameValidator;
+
+/**
+ * Validates a filename by creating a temporary file with the given name
+ * on the underlying filesystem. In addition, checks are made on reserved
+ * characters and words.
+ */
+public class FileNameValidator implements IFileNameValidator {
+
+    private static final String WINDOWS = "WINDOWS"; //$NON-NLS-1$
+
+    private static final String MAC = "MAC"; //$NON-NLS-1$
+
+    private class ValidatorStatus extends MultiStatus {
+
+        /**
+         * Create new instance
+         */
+        public ValidatorStatus() {
+            super(FoundationCorePlugin.PLUGIN_ID, IStatus.OK, Messages.FileNameValidatorValidationSuccessful, null);
+        }
+
+        @Override
+        protected void setMessage(String message) {
+            super.setMessage(message);
+        }
+    }
+
+    /**
+     * Root directory for testing files
+     */
+    private String parentDir = System.getProperty("java.io.tmpdir"); //$NON-NLS-1$
+
+    /**
+     * Collection of reserved characters that should not appear in filenames
+     */
+    private Collection<Character> reservedChars = new ArrayList<Character>();
+
+    /**
+     * Collection of reserved words that should not appear as filenames
+     */
+    private Collection<String> reservedWords = new ArrayList<String>();
+
+    /**
+     * @return given status is a failure
+     */
+    private boolean isFailure(IStatus status) {
+        return status.matches(IStatus.ERROR);
+    }
+
+    /**
+     * Create a failure status
+     */
+    private IStatus createFailureStatus(String message) {
+        return new Status(IStatus.ERROR, FoundationCorePlugin.PLUGIN_ID, message);
+    }
+
+    /**
+     * Set the warning message
+     */
+    private IStatus createWarningStatus(String message) {
+        return new Status(IStatus.WARNING, FoundationCorePlugin.PLUGIN_ID, message);
+    }
+
+    /**
+     * @return true if this system is running a Window OS, otherwise false
+     */
+    private boolean isWindows() {
+        return getOSValue().contains(WINDOWS);
+    }
+
+    /**
+     * @return true if this system is running a Window OS, otherwise false
+     */
+    private boolean isMac() {
+        return getOSValue().contains(MAC);
+    }
+
+    /**
+     * @return value representation of host OS
+     */
+    private String getOSValue() {
+        return System.getProperty("os.name").toUpperCase(); //$NON-NLS-1$
+    }
+
+    /**
+     * Test whether the given file name contains the nul character.
+     *
+     * This is applicable to all systems.
+     *
+     * @param fileName
+     *
+     * @return ok status if test passes, otherwise a failure status
+     */
+    private IStatus testNullCharacter(String fileName) {
+        if (fileName.contains(NUL)) {
+            return createFailureStatus(Messages.FileNameValidatorNullCharacter);
+        }
+
+        return Status.OK_STATUS;
+    }
+
+    /**
+     * File name should be less than or equal to 255 characters
+     *
+     * This is applicable to all systems.
+     *
+     * @param fileName
+     *
+     * @return ok status if test passes, otherwise a failure status
+     */
+    private IStatus testLength(String fileName) {
+        if (fileName.length() > 255) {
+            return createFailureStatus(Messages.FileNameValidatorTooLong);
+        }
+
+        return Status.OK_STATUS;
+    }
+
+    /**
+     * Test whether the given file name contains any of the set of
+     * reserved characters
+     *
+     * This is especially applicable to Windows and FAT file systems
+     *
+     * @param fileName
+     *
+     * @return ok status if test passes, otherwise a failure status
+     */
+    private IStatus testReservedChars(String fileName) {
+        /*
+         * User-added characters so test should fail if the file name
+         * contains them
+         */
+        for (char c : reservedChars) {
+            if (fileName.indexOf(c) > -1) {
+                return createFailureStatus(Messages.FileNameValidatorReservedCharacter);
+            }
+        }
+
+        /*
+         * Test for universal reserved characters
+         */
+        for (char c : RESERVED_CHARACTERS) {
+            if (fileName.indexOf(c) > -1) {
+                return createFailureStatus(Messages.FileNameValidatorReservedCharacter);
+            }
+        }
+
+        MultiStatus status = new MultiStatus(FoundationCorePlugin.PLUGIN_ID, IStatus.OK, "", null); //$NON-NLS-1$
+
+        /*
+         * Test for Mac reserved characters
+         */
+        for (char c : MAC_RESERVED_CHARACTERS) {
+            if (fileName.indexOf(c) > -1) {
+                if (isMac()) {
+                    return createFailureStatus(Messages.FileNameValidatorReservedCharacter);
+                } else {
+                    status.add(createWarningStatus(Messages.FileNameValidatorReservedCharacter));
+                }
+            }
+        }
+
+        /*
+         * Test for Windows reserved characters
+         */
+        for (char c : WIN_RESERVED_CHARACTERS) {
+            if (fileName.indexOf(c) > -1) {
+                if (isWindows()) {
+                    return createFailureStatus(Messages.FileNameValidatorReservedCharacter);
+                } else {
+                    status.add(createWarningStatus(Messages.FileNameValidatorReservedCharacter));
+                }
+            }
+        }
+
+        return status;
+    }
+
+    /**
+     * Tests whether the given filename is one of the reserved words
+     *
+     * This is especially applicable to Windows
+     *
+     * @param fileName
+     *
+     * @return ok status if test passes, otherwise a failure status
+     */
+    private IStatus testReservedWord(String fileName) {
+        int lastDot = fileName.lastIndexOf(DOT);
+        if (lastDot > -1)
+            fileName = fileName.substring(0, lastDot);
+
+        /*
+         * User-added words so test should fail if the file name
+         * contains them
+         */
+        for (String word : reservedWords) {
+            if (word.equalsIgnoreCase(fileName)) {
+                return createFailureStatus(Messages.FileNameValidatorReservedWord);
+            }
+        }
+
+        /*
+         * Test for universal reserved characters
+         */
+        for (String word : RESERVED_WORDS) {
+            if (word.equalsIgnoreCase(fileName)) {
+                return createFailureStatus(Messages.FileNameValidatorReservedWord);
+            }
+        }
+
+        MultiStatus status = new MultiStatus(FoundationCorePlugin.PLUGIN_ID, IStatus.OK, "", null); //$NON-NLS-1$
+
+        /*
+         * Test for Windows reserved words
+         */
+        for (String word : WIN_RESERVED_WORDS) {
+            if (word.equalsIgnoreCase(fileName)) {
+                if (isWindows()) {
+                    return createFailureStatus(Messages.FileNameValidatorReservedWord);
+                } else {
+                    status.add(createWarningStatus(Messages.FileNameValidatorReservedWord));
+                }
+            }
+        }
+
+        return status;
+    }
+
+    /**
+     * Test whether given file name contains a dot implying the presence
+     * of a suffix.
+     *
+     * This is applicable to Windows.
+     *
+     * @param fileName
+     *
+     * @return ok status if test passes, otherwise a failure status
+     */
+    private IStatus testSuffix(String fileName) {
+        int dotIndex = fileName.indexOf(DOT);
+        if (dotIndex < 1 || dotIndex >= fileName.length() - 1) {
+            // No suffix
+            if (isWindows()) {
+                return createFailureStatus(Messages.FileNameValidatorNoSuffix);
+            } else {
+                return createWarningStatus(Messages.FileNameValidatorNoSuffix);
+            }
+        }
+
+        return Status.OK_STATUS;
+    }
+
+    /**
+     * File name cannot end with a period or space.
+     *
+     * This is applicable to Windows
+     *
+     * @param fileName
+     *
+     * @return ok status if test passes, otherwise a failure status
+     */
+    private IStatus testIllegalFinalCharacter(String fileName) {
+
+        if (fileName.endsWith(DOT) || fileName.endsWith(SPACE)) {
+            if (getOSValue().contains(WINDOWS)) {
+                return createFailureStatus(Messages.FileNameValidatorEndsFinalCharacter);
+            } else {
+                return createWarningStatus(Messages.FileNameValidatorEndsFinalCharacter);
+            }
+        }
+
+        return Status.OK_STATUS;
+    }
+
+    private void evaluate(IStatus testStatus, ValidatorStatus outputStatus) {
+        if (! testStatus.isOK()) {
+            // Only care about failures and warnings
+            outputStatus.add(testStatus);
+
+            switch (outputStatus.getSeverity()) {
+                case IStatus.ERROR:
+                    outputStatus.setMessage(Messages.FileNameValidatorValidationFailed);
+                    break;
+                case IStatus.WARNING:
+                    outputStatus.setMessage(Messages.FileNameValidatorValidationWarning);
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Validate the given filename
+     *
+     * @param fileName
+     *
+     * @return status indicating the result of the validity of the filename
+     */
+    @Override
+    public IStatus validate(String fileName) {
+
+        if (fileName == null) {
+            return createFailureStatus(Messages.FileNameValidatorNullFileName);
+        }
+
+        ValidatorStatus resultStatus = new ValidatorStatus();
+
+        evaluate(testLength(fileName), resultStatus);
+        if (isFailure(resultStatus))
+            return resultStatus;
+
+        evaluate(testNullCharacter(fileName), resultStatus);
+        if (isFailure(resultStatus))
+            return resultStatus;
+
+        evaluate(testIllegalFinalCharacter(fileName), resultStatus);
+        if (isFailure(resultStatus))
+            return resultStatus;
+
+        evaluate(testReservedChars(fileName), resultStatus);
+        if (isFailure(resultStatus))
+            return resultStatus;
+
+        evaluate(testReservedWord(fileName), resultStatus);
+        if (isFailure(resultStatus))
+            return resultStatus;
+
+        evaluate(testSuffix(fileName), resultStatus);
+        if (isFailure(resultStatus))
+            return resultStatus;
+
+        /*
+         * Test a temporary file can be created with the file name
+         */
+        File tempTestFile = new File(parentDir, fileName);
+        try {
+
+            if (tempTestFile.createNewFile()) {
+                tempTestFile.delete();
+            } else
+                resultStatus.add(createFailureStatus(Messages.FileNameValidatorFailedToCreateTestFile));
+
+        } catch (Exception ex) {
+            StringBuilder builder = new StringBuilder(Messages.FileNameValidatorFailedToCreateTestFile);
+            builder.append("\n"); //$NON-NLS-1$
+            builder.append(ex.getLocalizedMessage());
+            resultStatus.add(createFailureStatus(builder.toString()));
+       }
+
+        return resultStatus;
+    }
+
+    /**
+     * Set the parent directory which will be used in the filename validation.
+     * In most cases, the default of java's temporary directory should be
+     * sufficient but if the filename is going to be used on a different filesystem
+     * then in may be prudent to test on this alternative filesystem.
+     *
+     * @param directory
+     */
+    @Override
+    public void setParentDirectory(String directory) {
+        this.parentDir = directory;
+    }
+
+    /**
+     * Adds a character that should not be used in a filename.
+     *
+     * This character will be checked in addition to the minimum
+     * list detailed in RESERVED_CHARACTERS.
+     *
+     * @param character
+     */
+    @Override
+    public void addReservedCharacter(Character character) {
+        reservedChars.add(character);
+    }
+
+    /**
+     * Adds a word that should not be used as a filename.
+     *
+     * Once added, this word cannot appear as either a single filename or
+     * a filename with a suffix.
+     *
+     * @param reservedWord
+     */
+    @Override
+    public void addReservedWord(String reservedWord) {
+        reservedWords .add(reservedWord);
+    }
+}

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/impl/Messages.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/impl/Messages.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.core.validate.impl;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = Messages.class.getPackage().getName() + ".messages";  //$NON-NLS-1$
+
+    public static String FileNameValidatorNullFileName;
+
+    public static String FileNameValidatorTooLong;
+
+    public static String FileNameValidatorEndsFinalCharacter;
+
+    public static String FileNameValidatorNullCharacter;
+
+    public static String FileNameValidatorReservedCharacter;
+
+    public static String FileNameValidatorReservedWord;
+
+    public static String FileNameValidatorNoSuffix;
+
+    public static String FileNameValidatorFailedToCreateTestFile;
+
+    public static String FileNameValidatorValidationWarning;
+
+    public static String FileNameValidatorValidationFailed;
+
+    public static String FileNameValidatorValidationSuccessful;
+
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/impl/messages.properties
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/validate/impl/messages.properties
@@ -1,0 +1,11 @@
+FileNameValidatorNullFileName=The given file name is null
+FileNameValidatorTooLong=The file name is too long. It should have a maximum length of 255 characters
+FileNameValidatorEndsFinalCharacter=The file name ends with a character not allowed on some file systems
+FileNameValidatorNullCharacter=The file name cannot contain the 'null' character
+FileNameValidatorReservedCharacter=The file name contains a reserved character
+FileNameValidatorReservedWord=The file name is a reserved word
+FileNameValidatorNoSuffix=The file name lacks an identifiable suffix
+FileNameValidatorFailedToCreateTestFile=The file name could not be used to create a test file, indicating the file name is not valid
+FileNameValidatorValidationWarning=The file name was validated successfully on this system but may not be portable to other systems.
+FileNameValidatorValidationFailed=The file name failed to be validated
+FileNameValidatorValidationSuccessful=The file name validated successfully

--- a/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/test/validate/impl/TestFileNameValidator.java
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/test/validate/impl/TestFileNameValidator.java
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.core.test.validate.impl;
+
+import junit.framework.TestCase;
+import org.eclipse.core.runtime.IStatus;
+import org.jboss.tools.foundation.core.validate.IFileNameValidator;
+import org.jboss.tools.foundation.core.validate.impl.FileNameValidator;
+import org.junit.Test;
+
+/**
+ * Test class for the {@link FileNameValidator}
+ */
+public class TestFileNameValidator extends TestCase {
+
+    private static final String WINDOWS = "WINDOWS"; //$NON-NLS-1$
+
+    private static final String MAC = "MAC"; //$NON-NLS-1$
+
+    /**
+     * @return true if this system is running a Window OS, otherwise false
+     */
+    private boolean isWindows() {
+        return getOSValue().contains(WINDOWS);
+    }
+
+    /**
+     * @return true if this system is running a Mac OS, otherwise false
+     */
+    private boolean isMac() {
+        return getOSValue().contains(MAC);
+    }
+
+    /**
+     * @return value representation of host OS
+     */
+    private String getOSValue() {
+        return System.getProperty("os.name").toUpperCase(); //$NON-NLS-1$
+    }
+
+    /**
+     * Test validation of valid filenames
+     */
+    @Test
+    public void testValidateValidFileNames() {
+        String[] validFileNames = {
+            "test345.xml", "test-345.txt", "test_345.doc", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "test.xmi", "test.txt", "test.xml", "test.csv", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        };
+
+        IFileNameValidator validator = new FileNameValidator();
+
+        for (String fileName : validFileNames) {
+            IStatus status = validator.validate(fileName);
+            assertEquals(IStatus.OK, status.getSeverity());
+        }
+    }
+
+    /**
+     * Test the validation of suffixed and non-suffixed filenames
+     */
+    @Test
+    public void testValidateSuffixes() {
+        String[] fileNamesNoSuffix = {
+            "test", "test345", "test-345", "test_345", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        };
+
+        IFileNameValidator validator = new FileNameValidator();
+
+        for (String fileName : fileNamesNoSuffix) {
+            IStatus status = validator.validate(fileName);
+            if (isWindows()) {
+                // Should fail since suffixes are preferred on windows
+                assertEquals(IStatus.ERROR, status.getSeverity());
+            } else {
+                // Should warn since the filename is not portable
+                assertEquals(IStatus.WARNING, status.getSeverity());
+            }
+        }
+    }
+
+    /**
+     * Tests the validation of filenames using the built-in universal reserved characters
+     */
+    @Test
+    public void testValidateReservedCharacters() {
+        IFileNameValidator validator = new FileNameValidator();
+
+        for (char c : IFileNameValidator.RESERVED_CHARACTERS) {
+            StringBuilder builder = new StringBuilder("te"); //$NON-NLS-1$
+            builder.append(c);
+            builder.append("st.xmi"); //$NON-NLS-1$
+
+            IStatus status = validator.validate(builder.toString());
+
+            // Should fail since reserved characters are forbidden on windows
+            assertEquals(IStatus.ERROR, status.getSeverity());
+        }
+    }
+
+    /**
+     * Tests the validation of filenames using the built-in mac reserved characters
+     */
+    @Test
+    public void testValidateMacReservedCharacters() {
+        IFileNameValidator validator = new FileNameValidator();
+
+        for (char c : IFileNameValidator.MAC_RESERVED_CHARACTERS) {
+            StringBuilder builder = new StringBuilder("te"); //$NON-NLS-1$
+            builder.append(c);
+            builder.append("st.xmi"); //$NON-NLS-1$
+
+            IStatus status = validator.validate(builder.toString());
+            if (isMac()) {
+                // Should fail since reserved characters are forbidden on windows
+                assertEquals(IStatus.ERROR, status.getSeverity());
+            } else {
+                // Should warn since the filename is not portable
+                assertEquals(IStatus.WARNING, status.getSeverity());
+            }
+        }
+    }
+
+    /**
+     * Tests the validation of filenames using the built-in windows reserved characters
+     */
+    @Test
+    public void testValidateWindowsReservedCharacters() {
+        IFileNameValidator validator = new FileNameValidator();
+
+        for (char c : IFileNameValidator.WIN_RESERVED_CHARACTERS) {
+            StringBuilder builder = new StringBuilder("te"); //$NON-NLS-1$
+            builder.append(c);
+            builder.append("st.xmi"); //$NON-NLS-1$
+
+            IStatus status = validator.validate(builder.toString());
+            if (isWindows()) {
+                // Should fail since reserved characters are forbidden on windows
+                assertEquals(IStatus.ERROR, status.getSeverity());
+            } else {
+                // Should warn since the filename is not portable
+                assertEquals(IStatus.WARNING, status.getSeverity());
+            }
+        }
+    }
+
+    /**
+     * Tests the loading and validation of added reserved characters
+     */
+    @Test
+    public void testValidateLoadedReservedCharacters() {
+        IFileNameValidator validator = new FileNameValidator();
+
+        char[] reservedChars = new char[] {
+            ')', '(', '[', ']', '@', '~', '#'
+        };
+
+        for (char reservedChar : reservedChars) {
+            validator.addReservedCharacter(reservedChar);
+        }
+
+        for (char c : reservedChars) {
+            StringBuilder builder = new StringBuilder("te"); //$NON-NLS-1$
+            builder.append(c);
+            builder.append("st.xmi"); //$NON-NLS-1$
+
+            IStatus status = validator.validate(builder.toString());
+
+            // Should always fail since the user added these reserved characters
+            assertEquals(IStatus.ERROR, status.getSeverity());
+        }
+    }
+
+    /**
+     * Tests the validation of filenames using the built-in universal reserved words
+     */
+    @Test
+    public void testValidateReservedWords() {
+        IFileNameValidator validator = new FileNameValidator();
+
+        for (String word : IFileNameValidator.RESERVED_WORDS) {
+            StringBuilder builder = new StringBuilder(word);
+            builder.append(".xmi"); //$NON-NLS-1$
+
+            IStatus status = validator.validate(builder.toString());
+            assertEquals(IStatus.ERROR, status.getSeverity());
+        }
+    }
+
+    /**
+     * Tests the validation of filenames using the built-in reserved words
+     */
+    @Test
+    public void testValidateWindowsReservedWords() {
+        IFileNameValidator validator = new FileNameValidator();
+
+        for (String word : IFileNameValidator.WIN_RESERVED_WORDS) {
+            StringBuilder builder = new StringBuilder(word);
+            builder.append(".xmi"); //$NON-NLS-1$
+
+            IStatus status = validator.validate(builder.toString());
+            if (isWindows()) {
+                // Should fail since reserved words are forbidden on windows
+                assertEquals(IStatus.ERROR, status.getSeverity());
+            } else {
+                // Should warn since the filename is not portable
+                assertEquals(IStatus.WARNING, status.getSeverity());
+            }
+        }
+    }
+
+    /**
+     * Tests the loading of reserved words and validation of them.
+     * All reserved words, whether singurlarly or with an extension,
+     * should fail the validator.
+     */
+    @Test
+    public void testValidateLoadedReservedWords() {
+        IFileNameValidator validator = new FileNameValidator();
+
+        String[] reservedWords = new String[] {
+            "Select", "From", "TEMP", "SYS", "SYSADMIN" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+        };
+
+        for (String reservedWord : reservedWords) {
+            validator.addReservedWord(reservedWord);
+        }
+
+        for (String reservedWord : reservedWords) {
+            // Test the word
+            IStatus status = validator.validate(reservedWord);
+
+            // Should always fail since the user added these reserved characters
+            assertEquals(IStatus.ERROR, status.getSeverity());
+        }
+    }
+}


### PR DESCRIPTION
== PULL REQUEST FOR DISCUSSION AND COMMENT. ALL INTERESTED PARTIES SHOULD BE IN AGREEMENT PRIOR TO MERGING ==
- FileNameValidator
  - Provides a single class that validates a file name against the underlying
    filesystem.
  - Single, centralised point for determining validity of file names.
  - Provides some fundamental rules concerning known filesystems and OSs
    which the file name must adhere to before even a test file is created.
  - Provides set of options to enhance the validator such as ability to add
    other reserved characters, add reserved words and modify the directory
    where the temporary file test is conducted.
- Factory provided with interface allowing alternative implementations
- Includes unit tests for validator implementation
