### PR TITLE
JBIDE-15652 JSF EL is proposed by content assist for plain HTML projects

### DIFF
--- a/common/tests/org.jboss.tools.common.el.core.test/src/org/jboss/tools/common/el/core/test/resolver/ELResolverFactory1.java
+++ b/common/tests/org.jboss.tools.common.el.core.test/src/org/jboss/tools/common/el/core/test/resolver/ELResolverFactory1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-  * Copyright (c) 2010 - 2012 Red Hat, Inc.
+  * Copyright (c) 2010 - 2013 Red Hat, Inc.
   * Distributed under license by Red Hat, Inc. All rights reserved.
   * This program is made available under the terms of the
   * Eclipse Public License v1.0 which accompanies this distribution,
@@ -11,7 +11,9 @@
 
 package org.jboss.tools.common.el.core.test.resolver;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
 import org.jboss.tools.common.el.core.resolver.ELResolver;
 import org.jboss.tools.common.el.core.resolver.ELResolverFactory;
 
@@ -21,7 +23,12 @@ public class ELResolverFactory1 implements ELResolverFactory {
 	}
 
 	public ELResolver createResolver(IResource resource) {
-		return new ResolverProjectNature1();
+		IProject project = resource == null ? null : resource.getProject();
+		try {
+			return (project != null && project.hasNature(ProjectNature1.ID) ? 
+					new ResolverProjectNature1() : null);
+		} catch (CoreException e) {
+			return null;
+		}
 	}
-
 }

--- a/common/tests/org.jboss.tools.common.el.core.test/src/org/jboss/tools/common/el/core/test/resolver/ELResolverFactoryManagerTest.java
+++ b/common/tests/org.jboss.tools.common.el.core.test/src/org/jboss/tools/common/el/core/test/resolver/ELResolverFactoryManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-  * Copyright (c) 2010 - 2012 Red Hat, Inc.
+  * Copyright (c) 2010 - 2013 Red Hat, Inc.
   * Distributed under license by Red Hat, Inc. All rights reserved.
   * This program is made available under the terms of the
   * Eclipse Public License v1.0 which accompanies this distribution,
@@ -20,7 +20,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.jboss.tools.common.el.core.resolver.ELResolver;
 import org.jboss.tools.common.el.core.resolver.ELResolverFactoryManager;
 import org.jboss.tools.test.resource.ResourceFactory;
-import org.junit.Test;
 
 public class ELResolverFactoryManagerTest extends TestCase{
 


### PR DESCRIPTION
Issue is fixed by restricting ELResolverFactory1 to create its EL Resolver only for projects that has ProjectNature1.ID Nature
(== "org.jboss.tools.common.el.core.test.project-nature1").
