### PR TITLE
JBIDE-12646 web.xml servlet-name validation is not case-sensitive

### DIFF
--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/util/EclipseResourceUtil.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/util/EclipseResourceUtil.java
@@ -48,7 +48,6 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.wst.common.componentcore.ComponentCore;
-import org.eclipse.wst.common.componentcore.ModuleCoreNature;
 import org.eclipse.wst.common.componentcore.resources.IVirtualComponent;
 import org.jboss.tools.common.EclipseUtil;
 import org.jboss.tools.common.meta.action.XActionInvoker;
@@ -70,6 +69,7 @@ import org.jboss.tools.common.model.plugin.ModelPlugin;
 import org.jboss.tools.common.model.project.IModelNature;
 import org.jboss.tools.common.model.project.ModelNature;
 import org.jboss.tools.common.model.project.ModelNatureExtension;
+import org.jboss.tools.common.util.FileUtils;
 import org.jboss.tools.common.web.WebUtils;
 import org.osgi.framework.Bundle;
 
@@ -804,7 +804,8 @@ public class EclipseResourceUtil extends EclipseUtil {
 			if(r == null || r.getLocation() == null) return false;
 			String output = r.getLocation().toString();
 			String f = output + XModelObjectConstants.SEPARATOR + className.replace('.', '/') + ".class"; //$NON-NLS-1$
-			return new java.io.File(f).isFile();
+			File file = new File(f);
+			return file.isFile() && FileUtils.isSameFile(file);
 		} catch (JavaModelException t) {
 			ModelPlugin.getPluginLog().logError("Error checking class " + className, t); //$NON-NLS-1$
 			return false;

--- a/common/tests/org.jboss.tools.common.model.test/src/org/jboss/tools/common/model/util/test/EclipseJavaUtilTest.java
+++ b/common/tests/org.jboss.tools.common.model.test/src/org/jboss/tools/common/model/util/test/EclipseJavaUtilTest.java
@@ -89,4 +89,9 @@ public class EclipseJavaUtilTest extends TestCase {
 		
 	}
 
+	public void testIsContainedInOutput() throws Exception {
+		assertTrue(EclipseResourceUtil.isContainedInOutput(project1, "demo.User"));
+		assertFalse(EclipseResourceUtil.isContainedInOutput(project1, "demo.user"));
+	}
+
 }


### PR DESCRIPTION
Method EclipseResourceUtil.isContainedInOutput() is fixed to be
case sensitive.
