### PR TITLE
JBIDE-16135 EL Content Assist in Java Editor: Make Content Assistant Add...

### DIFF
--- a/common/plugins/org.jboss.tools.common.el.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.el.ui/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.el.ui;singleton:=true
 Bundle-Version: 3.6.0.qualifier
 Export-Package: org.jboss.tools.common.el.ui,
- org.jboss.tools.common.el.ui.ca
+ org.jboss.tools.common.el.ui.ca,
+ org.jboss.tools.common.el.ui.internal.info
 Bundle-Activator: org.jboss.tools.common.el.ui.ElUiPlugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.jboss.tools.common.el.core,

--- a/common/plugins/org.jboss.tools.common.el.ui/build.properties
+++ b/common/plugins/org.jboss.tools.common.el.ui/build.properties
@@ -1,7 +1,9 @@
-source.. = src/
+source.. = src/,\
+           resources/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties,\
                plugin.xml,\
-               about.html
+               about.html,\
+               resources/

--- a/common/plugins/org.jboss.tools.common.el.ui/resources/css/ELInfoHoverStyleSheet.css
+++ b/common/plugins/org.jboss.tools.common.el.ui/resources/css/ELInfoHoverStyleSheet.css
@@ -1,0 +1,34 @@
+/* Font definitions */
+html         { font-family: sans-serif; font-size: 9pt; font-style: normal; font-weight: normal; }
+body, h1, h2, h3, h4, h5, h6, p, table, td, caption, th, ul, ol, dl, li, dd, dt { font-size: 1em; }
+pre          { font-family: monospace; }
+
+/* Margins */
+body	     { overflow: auto; margin-top: 0px; margin-bottom: 0.5em; margin-left: 0.3em; margin-right: 0px; }
+h1           { margin-top: 0.3em; margin-bottom: 0.04em; }	
+h2           { margin-top: 2em; margin-bottom: 0.25em; }
+h3           { margin-top: 1.7em; margin-bottom: 0.25em; }
+h4           { margin-top: 2em; margin-bottom: 0.3em; }
+h5           { margin-top: 0px; margin-bottom: 0px; }
+p            { margin-top: 1em; margin-bottom: 1em; }
+pre          { margin-left: 0.6em; }
+ul	         { margin-top: 0px; margin-bottom: 1em; margin-left: 1em; padding-left: 1em;}
+li	         { margin-top: 0px; margin-bottom: 0px; } 
+li p	     { margin-top: 0px; margin-bottom: 0px; } 
+ol	         { margin-top: 0px; margin-bottom: 1em; margin-left: 1em; padding-left: 1em; }
+dl	         { margin-top: 0px; margin-bottom: 1em; }
+dt	         { margin-top: 0px; margin-bottom: 0px; font-weight: bold; }
+dd	         { margin-top: 0px; margin-bottom: 0px; }
+
+/* Styles and colors */
+a:link	     { color: #0000FF; }
+a:hover	     { color: #000080; }
+a:visited    { text-decoration: underline; }
+a.header:link    { text-decoration: none; color: InfoText }
+a.header:visited { text-decoration: none; color: InfoText }
+a.header:hover   { text-decoration: underline; color: #000080; }
+h4           { font-style: italic; }
+strong	     { font-weight: bold; }
+em	         { font-style: italic; }
+var	         { font-style: italic; }
+th	         { font-weight: bold; }

--- a/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/ca/ELProposalProcessor.java
+++ b/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/ca/ELProposalProcessor.java
@@ -11,27 +11,18 @@
 
 package org.jboss.tools.common.el.ui.ca;
 
-import java.io.Reader;
-import java.io.StringReader;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.IMember;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
-import org.eclipse.jdt.internal.ui.text.javadoc.JavadocContentAccess2;
-import org.eclipse.jdt.internal.ui.viewsupport.JavaElementLinks;
-import org.eclipse.jdt.ui.JavaElementLabels;
 import org.eclipse.jdt.ui.PreferenceConstants;
-import org.eclipse.jface.internal.text.html.HTMLPrinter;
+import org.eclipse.jface.internal.text.html.BrowserInformationControl;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
@@ -43,10 +34,13 @@ import org.eclipse.jface.text.contentassist.ICompletionProposalExtension;
 import org.eclipse.jface.text.contentassist.ICompletionProposalExtension2;
 import org.eclipse.jface.text.contentassist.ICompletionProposalExtension3;
 import org.eclipse.jface.text.contentassist.ICompletionProposalExtension4;
+import org.eclipse.jface.text.contentassist.ICompletionProposalExtension5;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.editors.text.EditorsUI;
@@ -67,8 +61,8 @@ import org.jboss.tools.common.el.core.resolver.ELContext;
 import org.jboss.tools.common.el.core.resolver.ELResolver;
 import org.jboss.tools.common.el.core.resolver.ELResolverFactoryManager;
 import org.jboss.tools.common.el.ui.ElUiPlugin;
-import org.jboss.tools.common.model.XModelObject;
-import org.jboss.tools.common.model.filesystems.impl.JarSystemImpl;
+import org.jboss.tools.common.el.ui.internal.info.ELInfoHover;
+import org.jboss.tools.common.el.ui.internal.info.Messages;
 import org.jboss.tools.common.text.TextProposal;
 import org.jboss.tools.common.text.ext.util.Utils;
 import org.jboss.tools.common.ui.CommonUIPlugin;
@@ -84,6 +78,7 @@ import org.w3c.dom.Text;
  * 
  * @author Victor Rubezhny
  */
+@SuppressWarnings("restriction")
 public abstract class ELProposalProcessor extends AbstractContentAssistProcessor {
 
 	private static final ICompletionProposal[] NO_PROPOSALS= new ICompletionProposal[0];
@@ -98,7 +93,7 @@ public abstract class ELProposalProcessor extends AbstractContentAssistProcessor
 		}	
 	};
 
-	public static final class Proposal implements ICompletionProposal, ICompletionProposalExtension, ICompletionProposalExtension2, ICompletionProposalExtension3, ICompletionProposalExtension4, IRelevanceCompletionProposal {
+	public static final class Proposal implements ICompletionProposal, ICompletionProposalExtension, ICompletionProposalExtension2, ICompletionProposalExtension3, ICompletionProposalExtension4, ICompletionProposalExtension5, IRelevanceCompletionProposal {
 
 		private final String fString;
 		private final String fPrefix;
@@ -107,9 +102,13 @@ public abstract class ELProposalProcessor extends AbstractContentAssistProcessor
 		private int fNewPosition;
 		private String fDisplayString;
 		private String fAlternateMatch;
-		private String fAdditionalProposalInfo;
+		private Object fAdditionalProposalInfo;
 		private IJavaElement[] fJavaElements;
 		private MessagesELTextProposal fPropertySource;
+		/**
+		 * The control creator.
+		 */
+		private IInformationControlCreator fCreator;
 
 		private Image fImage;
 
@@ -163,158 +162,25 @@ public abstract class ELProposalProcessor extends AbstractContentAssistProcessor
 		 * @see org.eclipse.jface.text.contentassist.ICompletionProposal#getAdditionalProposalInfo()
 		 */
 		public String getAdditionalProposalInfo() {
+			Object info= getAdditionalProposalInfo(new NullProgressMonitor());
+			return info == null ? null : info.toString();
+		}
+
+		private static final String EMPTY_ADDITIONAL_INFO = new String();
+		@Override
+		public Object getAdditionalProposalInfo(IProgressMonitor monitor) {
 			if (fAdditionalProposalInfo == null) {
 				if (this.fJavaElements != null && this.fJavaElements.length > 0) {
-					Arrays.sort(this.fJavaElements, ELProposalProcessor.CASE_INSENSITIVE_ORDER);
-					this.fAdditionalProposalInfo = extractProposalContextInfo(fJavaElements);
+					fAdditionalProposalInfo = ELInfoHover.getHoverInfo(fJavaElements, monitor);
 				} else if (fPropertySource != null) {
-					this.fAdditionalProposalInfo = extractProposalContextInfo(fPropertySource);
+					fAdditionalProposalInfo = ELInfoHover.getHoverInfo(
+							fPropertySource.getBaseName(), fPropertySource.getPropertyName(), 
+							fPropertySource.getAllObjects(), monitor);
 				}
 			}
 			if (fAdditionalProposalInfo == null) 
-				fAdditionalProposalInfo = ""; // This is to prevent repeat of extracting Java Info //$NON-NLS-1$
+				fAdditionalProposalInfo = EMPTY_ADDITIONAL_INFO;
 			return fAdditionalProposalInfo;
-		}
-
-		/*
-		 * Extracts the additional proposal information based on Javadoc for the stored IJavaElement objects
-		 */
-		private String extractProposalContextInfo(IJavaElement[] elements) {
-			int nResults= elements.length;
-			StringBuffer buffer= new StringBuffer();
-			boolean hasContents= false;
-			IJavaElement element= null;
-
-			if (nResults > 1) {
-	/*			for (int i= 0; i < elements.length; i++) {
-					if (elements[i] == null) continue;
-					if (elements[i] instanceof IMember || 
-							elements[i].getElementType() == IJavaElement.LOCAL_VARIABLE || 
-							elements[i].getElementType() == IJavaElement.TYPE_PARAMETER) {
-						buffer.append('\uE467').append(' ').append(getInfoText(elements[i]));
-						hasContents= true;
-					}
-					buffer.append("<br/>"); //$NON-NLS-1$
-				}
-	*/
-				for (int i=0; i < elements.length; i++) {
-					if (elements[i] == null) continue;
-					if (elements[i] instanceof IMember || 
-							elements[i].getElementType() == IJavaElement.LOCAL_VARIABLE || 
-							elements[i].getElementType() == IJavaElement.TYPE_PARAMETER) {
-						buffer.append('\uE467').append(' ');
-						addFullInfo(buffer, elements[i]);
-						buffer.append("<br/>"); //$NON-NLS-1$
-						hasContents = true;
-					}
-				}
-			} else {
-				element= elements[0];
-				if (element instanceof IMember ||
-						element.getElementType() == IJavaElement.LOCAL_VARIABLE || 
-						element.getElementType() == IJavaElement.TYPE_PARAMETER) {
-					addFullInfo(buffer, element);
-					hasContents= true;
-				}
-			}
-
-			if (!hasContents)
-				return null;
-
-			if (buffer.length() > 0) {
-				HTMLPrinter.insertPageProlog(buffer, 0, (String)null);
-				HTMLPrinter.addPageEpilog(buffer);
-				return buffer.toString();
-			}
-
-			return null;
-		}
-
-		/*
-		 * Extracts the additional proposal information based on Javadoc for the stored IJavaElement objects
-		 */
-		private String extractProposalContextInfo(MessagesELTextProposal propertySource) {
-			String propertyName = propertySource.getPropertyName();
-			String baseName = propertySource.getBaseName();
-			List<XModelObject> objects = (List<XModelObject>)propertySource.getAllObjects();
-			
-			String info = getELMessagesHoverInternal(baseName, propertyName, objects);
-			if (info == null) return null;
-
-			StringBuffer buffer= new StringBuffer(info);
-			HTMLPrinter.insertPageProlog(buffer, 0, (String)null);
-			HTMLPrinter.addPageEpilog(buffer);
-			return buffer.toString();
-		}
-
-		private static final long LABEL_FLAGS=  JavaElementLabels.ALL_FULLY_QUALIFIED
-				| JavaElementLabels.M_PRE_RETURNTYPE | JavaElementLabels.M_PARAMETER_TYPES | JavaElementLabels.M_PARAMETER_NAMES | JavaElementLabels.M_EXCEPTIONS
-				| JavaElementLabels.F_PRE_TYPE_SIGNATURE | JavaElementLabels.M_PRE_TYPE_PARAMETERS | JavaElementLabels.T_TYPE_PARAMETERS
-				| JavaElementLabels.USE_RESOLVED;
-		private static final long LOCAL_VARIABLE_FLAGS= LABEL_FLAGS & ~JavaElementLabels.F_FULLY_QUALIFIED | JavaElementLabels.F_POST_QUALIFIED;
-		private static final long TYPE_PARAMETER_FLAGS= LABEL_FLAGS | JavaElementLabels.TP_POST_QUALIFIED;
-
-		/* 
-		 * Returns the label for the IJavaElement objects
-		 */
-		private String getInfoText(IJavaElement element) {
-			long flags;
-			switch (element.getElementType()) {
-				case IJavaElement.LOCAL_VARIABLE:
-					flags= LOCAL_VARIABLE_FLAGS;
-					break;
-				case IJavaElement.TYPE_PARAMETER:
-					flags= TYPE_PARAMETER_FLAGS;
-					break;
-				default:
-					flags= LABEL_FLAGS;
-					break;
-			}
-			StringBuffer label= new StringBuffer(JavaElementLinks.getElementLabel(element, flags));
-		
-			// The following lines were commented out because of JBIDE-8923 faced in Eclipse 3.7
-			//
-//				StringBuffer buf= new StringBuffer();
-//				buf.append("<span style='word-wrap:break-word;'>"); //$NON-NLS-1$
-//				buf.append(label);
-//				buf.append("</span>"); //$NON-NLS-1$
-
-//				return buf.toString();
-			return label.toString();
-		}
-
-		/*
-		 * Adds full information to the additional proposal information
-		 * 
-		 * @param buffer
-		 * @param element
-		 * @return
-		 */
-		private void addFullInfo(StringBuffer buffer, IJavaElement element) {
-			if (element instanceof IMember) {
-				IMember member= (IMember) element;
-				HTMLPrinter.addSmallHeader(buffer, getInfoText(member));
-				Reader reader = null;
-				try {
-					String content= JavadocContentAccess2.getHTMLContent(member, true);
-					reader= content == null ? null : new StringReader(content);
-				} catch (JavaModelException ex) {
-					JavaPlugin.log(ex);
-				}
-				
-				if (reader == null) {
-					reader = new StringReader(Messages.NO_JAVADOC);
-				}
-
-				if (reader != null) {
-					buffer.append("<br/>"); //$NON-NLS-1$
-					buffer.append(HTMLPrinter.read(reader));
-//						HTMLPrinter.addParagraph(buffer, reader);
-				}
-
-			} else if (element.getElementType() == IJavaElement.LOCAL_VARIABLE || element.getElementType() == IJavaElement.TYPE_PARAMETER) {
-				HTMLPrinter.addSmallHeader(buffer, getInfoText(element));
-			}
 		}
 
 		/*
@@ -430,7 +296,23 @@ public abstract class ELProposalProcessor extends AbstractContentAssistProcessor
 		 * @see org.eclipse.jface.text.contentassist.ICompletionProposalExtension3#getInformationControlCreator()
 		 */
 		public IInformationControlCreator getInformationControlCreator() {
-			return null;
+			final boolean[] browserInformationControlAvailable = new boolean[] {false};
+			Display.getDefault().syncExec(new Runnable() {
+				@Override
+				public void run() {
+					Shell shell= JavaPlugin.getActiveWorkbenchShell();
+					browserInformationControlAvailable[0] = (shell != null && BrowserInformationControl.isAvailable(shell));
+				}
+			});
+			
+			if (!browserInformationControlAvailable[0])
+				return null;
+
+			if (fCreator == null) {
+				ELInfoHover.PresenterControlCreator presenterControlCreator= new ELInfoHover.PresenterControlCreator(ELInfoHover.getSite());
+				fCreator= new ELInfoHover.HoverControlCreator(presenterControlCreator, Messages.additionalInfo_affordance);
+			}
+			return fCreator;
 		}
 
 		/*
@@ -490,7 +372,6 @@ public abstract class ELProposalProcessor extends AbstractContentAssistProcessor
 		public void setfAlternateMatch(String fAlternateMatch) {
 			this.fAlternateMatch = fAlternateMatch;
 		}
-
 	}
 
 	/**
@@ -885,78 +766,4 @@ public abstract class ELProposalProcessor extends AbstractContentAssistProcessor
 	public String getErrorMessage() {
 		return null; // no custom error message
 	}
-	
-	public static String getELMessagesHoverInternal(String baseName, String propertyName, List<XModelObject> objects) {
-		StringBuffer buffer= new StringBuffer();
-
-		if (propertyName != null && propertyName.length() > 0) 
-			buffer.append(MessageFormat.format(Messages.ELInfoHover_propertyName, 
-				propertyName));
-			
-		if (baseName != null && baseName.length() > 0)
-			buffer.append(MessageFormat.format(Messages.ELInfoHover_baseName, 
-					baseName));
-		
-		if (objects != null) {
-			boolean firstValue = true;
-			for (XModelObject o : objects) {
-				IFile propFile = (IFile)o.getAdapter(IFile.class);
-				String propFilePath = null;
-				if (propFile != null) {
-					propFilePath = propFile.getFullPath().toString();
-				} else {
-					XModelObject parent = o.getFileType() == XModelObject.FILE ? o : o.getParent();
-					String path = parent.getPath();
-					while (parent != null && parent.getFileType() != XModelObject.SYSTEM) {
-						parent = parent.getParent();
-					}
-					if (parent instanceof JarSystemImpl) {
-						String sysPath = parent.getPath();
-						path = path.substring(sysPath.length());
-	
-						String jarPath = ((JarSystemImpl) parent).getLocation();
-						
-						IResource jar = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(new Path(jarPath));
-						
-						if (jar != null) {
-							jarPath = jar.getFullPath().toString();
-						}
-						
-						propFilePath = jarPath + "!" + path; //$NON-NLS-1$
-					}
-				}
-				buffer.append(Messages.ELInfoHover_newLine);
-				if (!firstValue) buffer.append(Messages.ELInfoHover_newLine);
-				else firstValue = false;
-				
-				buffer.append(MessageFormat.format(Messages.ELInfoHover_resourceBundle, 
-						propFilePath != null ? propFilePath : Messages.ELInfoHover_resourceBundleNotDefined));
-				
-				if (propertyName != null) {
-					String value = o.get("VALUE");  //$NON-NLS-1$
-					boolean addCut = false;
-					if (value != null) {
-						if (value.length() > 100) {
-							// Get first words of value
-							int lastSpace = value.lastIndexOf(' ', 99);
-							if (lastSpace != -1) {
-								value = value.substring(0, lastSpace);
-							} else { // cut as is
-								value = value.substring(0, 100);
-							}
-							addCut = true;
-						}
-					}
-					buffer.append(Messages.ELInfoHover_newLine);
-					buffer.append(MessageFormat.format(Messages.ELInfoHover_resourceBundlePropertyValue, 
-							value != null ? value : Messages.ELInfoHover_resourceBundlePropertyValueNotDefined,
-									addCut ? Messages.ELInfoHover_treeDots : "")); //$NON-NLS-1$
-//					sb.append(Messages.ELInfoHover_newLine);
-				}
-			}
-		}
-
-		return buffer.length() == 0 ? null : buffer.toString();
-	}
-
 }

--- a/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/internal/info/ELBrowserInformationControlInput.java
+++ b/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/internal/info/ELBrowserInformationControlInput.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/ 
+package org.jboss.tools.common.el.ui.internal.info;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.internal.ui.text.java.hover.JavadocBrowserInformationControlInput;
+
+/**
+ * Browser information control input instance
+ * 
+ * @author Victor V. Rubezhny
+ *
+ */
+public class ELBrowserInformationControlInput extends JavadocBrowserInformationControlInput {
+	private final IJavaElement[] fElements;
+
+	public ELBrowserInformationControlInput(
+			JavadocBrowserInformationControlInput previous,
+			IJavaElement[] elements, String html, int leadingImageWidth) {
+		super(previous, null, html, leadingImageWidth);
+		this.fElements = elements;
+	}
+
+	/**
+	 * Returns the Java elements.
+	 *
+	 * @return the elements or <code>null</code> if none available
+	 */
+	public IJavaElement[] getElements() {
+		return fElements;
+	}
+	
+	/*
+	 * @see org.eclipse.jdt.internal.ui.infoviews.BrowserInput#getInputName()
+	 */
+	@Override
+	public String getInputName() {
+		return fElements == null || fElements.length == 0? "" : fElements[0].getElementName(); //$NON-NLS-1$
+	}
+}

--- a/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/internal/info/ELInfoHover.java
+++ b/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/internal/info/ELInfoHover.java
@@ -1,0 +1,829 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/ 
+package org.jboss.tools.common.el.ui.internal.info;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.JavaPluginImages;
+import org.eclipse.jdt.internal.ui.actions.OpenBrowserUtil;
+import org.eclipse.jdt.internal.ui.actions.SimpleSelectionProvider;
+import org.eclipse.jdt.internal.ui.infoviews.JavadocView;
+import org.eclipse.jdt.internal.ui.text.java.hover.JavadocBrowserInformationControlInput;
+import org.eclipse.jdt.internal.ui.text.java.hover.JavadocHover;
+import org.eclipse.jdt.internal.ui.text.javadoc.JavadocContentAccess2;
+import org.eclipse.jdt.internal.ui.viewsupport.BasicElementLabels;
+import org.eclipse.jdt.internal.ui.viewsupport.JavaElementLinks;
+import org.eclipse.jdt.ui.JavaElementLabels;
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jdt.ui.actions.OpenAttachedJavadocAction;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.ToolBarManager;
+import org.eclipse.jface.internal.text.html.BrowserInformationControl;
+import org.eclipse.jface.internal.text.html.BrowserInformationControlInput;
+import org.eclipse.jface.internal.text.html.BrowserInput;
+import org.eclipse.jface.internal.text.html.HTMLPrinter;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.text.AbstractReusableInformationControlCreator;
+import org.eclipse.jface.text.DefaultInformationControl;
+import org.eclipse.jface.text.IInformationControl;
+import org.eclipse.jface.text.IInformationControlCreator;
+import org.eclipse.jface.text.IInformationControlExtension4;
+import org.eclipse.jface.text.IInputChangedListener;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.browser.LocationEvent;
+import org.eclipse.swt.browser.LocationListener;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchSite;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.wst.xml.ui.internal.taginfo.XMLTagInfoHoverProcessor;
+import org.jboss.tools.common.el.ui.ElUiPlugin;
+import org.jboss.tools.common.el.ui.ca.ELProposalProcessor;
+import org.jboss.tools.common.model.XModelObject;
+import org.jboss.tools.common.model.filesystems.impl.JarSystemImpl;
+import org.osgi.framework.Bundle;
+
+/**
+ * A utility class for Hover Info and Content Assist Additional Info creation
+ * 
+ * @author Victor V. Rubezhny
+ *
+ */
+@SuppressWarnings("restriction")
+public class ELInfoHover extends XMLTagInfoHoverProcessor {
+	
+	private IInformationControlCreator fHoverControlCreator;
+	private IInformationControlCreator fPresenterControlCreator;
+
+	/*
+	 * @see org.eclipse.jdt.internal.ui.text.java.hover.AbstractJavaEditorTextHover#getInformationPresenterControlCreator()
+	 */
+	public IInformationControlCreator getInformationPresenterControlCreator() {
+		final boolean[] browserInformationControlAvailable = new boolean[] {false};
+		Display.getDefault().syncExec(new Runnable() {
+			@Override
+			public void run() {
+				Shell shell= JavaPlugin.getActiveWorkbenchShell();
+				browserInformationControlAvailable[0] = (shell != null && BrowserInformationControl.isAvailable(shell));
+			}
+		});
+		
+		if (!browserInformationControlAvailable[0])
+			return null;
+		
+		if (fPresenterControlCreator == null)
+			fPresenterControlCreator= new PresenterControlCreator(getSite());
+		return fPresenterControlCreator;
+	}
+	/*
+	 * @see ITextHoverExtension#getHoverControlCreator()
+	 */
+	@Override
+	public IInformationControlCreator getHoverControlCreator() {
+		if (fHoverControlCreator == null)
+			fHoverControlCreator= new HoverControlCreator(getInformationPresenterControlCreator(), null);
+		return fHoverControlCreator;
+	}
+	
+	public static Object getHoverInfo(String info, IProgressMonitor monitor) {
+		if (info != null && info.length() > 0) {
+			StringBuffer buffer= new StringBuffer();
+			HTMLPrinter.insertPageProlog(buffer, 0, getCSSStyles());
+			buffer.append(info.trim());
+			HTMLPrinter.addPageEpilog(buffer);
+			
+			return new ELBrowserInformationControlInput(null, null, processLinks(buffer.toString()), 0);
+		}
+		return null;
+	}
+	
+	public static Object getHoverInfo(IJavaElement[] javaElements, IProgressMonitor monitor) {
+		if (javaElements != null && javaElements.length > 0) {
+			Arrays.sort(javaElements, ELProposalProcessor.CASE_INSENSITIVE_ORDER);
+			return new ELBrowserInformationControlInput(null, javaElements, 
+					processLinks(extractProposalContextInfo(javaElements)), 0);
+		}
+		return null;
+	}
+
+	public static Object getHoverInfo(String baseName, String propertyName, Object allObjects,  IProgressMonitor monitor) {
+		String info = extractProposalContextInfo(baseName, propertyName, allObjects);
+		return info != null ? new ELBrowserInformationControlInput(null, null, processLinks(info), 0) : null;
+	}
+
+	public static IWorkbenchSite getSite() {
+		IWorkbench workBench = ElUiPlugin.getDefault() == null ? null : ElUiPlugin.getDefault().getWorkbench();
+		IWorkbenchWindow window = workBench == null ? null : workBench.getActiveWorkbenchWindow();
+		IWorkbenchPage page = window == null ? null : window.getActivePage();
+		IWorkbenchPart part = page == null ? null : page.getActivePart();
+		return part == null ? null : part.getSite();
+	}
+	
+	/*
+	 * Extracts the additional proposal information based on Javadoc for the
+	 * stored IJavaElement objects
+	 */
+	private static String extractProposalContextInfo(IJavaElement[] elements) {
+		int nResults = elements.length;
+		StringBuffer buffer = new StringBuffer();
+		boolean hasContents = false;
+		IJavaElement element = null;
+
+		if (nResults > 1) {
+			for (int i = 0; i < elements.length; i++) {
+				if (elements[i] == null)
+					continue;
+				if (elements[i] instanceof IMember
+						|| elements[i].getElementType() == IJavaElement.LOCAL_VARIABLE
+						|| elements[i].getElementType() == IJavaElement.TYPE_PARAMETER) {
+					addFullInfo(buffer, elements[i]);
+					buffer.append("<br/>"); //$NON-NLS-1$
+					hasContents = true;
+				}
+			}
+		} else {
+			element = elements[0];
+			if (element instanceof IMember
+					|| element.getElementType() == IJavaElement.LOCAL_VARIABLE
+					|| element.getElementType() == IJavaElement.TYPE_PARAMETER) {
+				addFullInfo(buffer, element);
+				hasContents = true;
+			}
+		}
+
+		if (!hasContents || buffer.length() == 0)
+			return null;
+
+		HTMLPrinter.insertPageProlog(buffer, 0, getCSSStyles());
+		HTMLPrinter.addPageEpilog(buffer);
+		return buffer.toString();
+	}
+
+	/*
+	 * Adds full information to the additional proposal information
+	 * 
+	 * @param buffer
+	 * 
+	 * @param element
+	 * 
+	 * @return
+	 */
+	private static void addFullInfo(StringBuffer buffer, IJavaElement element) {
+		if (element instanceof IMember) {
+			IMember member = (IMember) element;
+			HTMLPrinter.addSmallHeader(buffer, getInfoText(member));
+			Reader reader = null;
+			try {
+				String content = JavadocContentAccess2.getHTMLContent(member,
+						true);
+				reader = content == null ? null : new StringReader(content);
+			} catch (JavaModelException ex) {
+				ElUiPlugin.getDefault().logError(ex);
+			}
+
+			if (reader == null) {
+				reader = new StringReader(Messages.NO_JAVADOC);
+			}
+
+			if (reader != null) {
+				buffer.append("<br/>"); //$NON-NLS-1$
+				buffer.append(HTMLPrinter.read(reader));
+			}
+
+		} else if (element.getElementType() == IJavaElement.LOCAL_VARIABLE
+				|| element.getElementType() == IJavaElement.TYPE_PARAMETER) {
+			HTMLPrinter.addSmallHeader(buffer, getInfoText(element));
+		}
+	}
+	
+	private static final long LABEL_FLAGS = JavaElementLabels.ALL_FULLY_QUALIFIED
+			| JavaElementLabels.M_PRE_RETURNTYPE
+			| JavaElementLabels.M_PARAMETER_TYPES
+			| JavaElementLabels.M_PARAMETER_NAMES
+			| JavaElementLabels.M_EXCEPTIONS
+			| JavaElementLabels.F_PRE_TYPE_SIGNATURE
+			| JavaElementLabels.M_PRE_TYPE_PARAMETERS
+			| JavaElementLabels.T_TYPE_PARAMETERS
+			| JavaElementLabels.USE_RESOLVED;
+	private static final long LOCAL_VARIABLE_FLAGS = LABEL_FLAGS
+			& ~JavaElementLabels.F_FULLY_QUALIFIED
+			| JavaElementLabels.F_POST_QUALIFIED;
+	private static final long TYPE_PARAMETER_FLAGS = LABEL_FLAGS
+			| JavaElementLabels.TP_POST_QUALIFIED;
+
+	/*
+	 * Returns the label for the IJavaElement objects
+	 */
+	private static String getInfoText(IJavaElement element) {
+		long flags;
+		switch (element.getElementType()) {
+		case IJavaElement.LOCAL_VARIABLE:
+			flags = LOCAL_VARIABLE_FLAGS;
+			break;
+		case IJavaElement.TYPE_PARAMETER:
+			flags = TYPE_PARAMETER_FLAGS;
+			break;
+		default:
+			flags = LABEL_FLAGS;
+			break;
+		}
+
+		return JavadocHover.getImageAndLabel(element, true, JavaElementLinks.getElementLabel(element, flags, true));
+	}
+
+	/*
+	 * Extracts the additional proposal information based on Javadoc for the
+	 * stored IJavaElement objects
+	 */
+	private static String extractProposalContextInfo(
+			String baseName, String propertyName, Object allObjects) {
+		Assert.isTrue(allObjects instanceof List<?>);
+		
+		String info = getELMessagesHoverInternal(
+				baseName, propertyName, (List<XModelObject>) allObjects);
+		
+		if (info == null) return null;
+		
+		StringBuffer buffer = new StringBuffer();
+		buffer.append(info);
+
+		if (buffer.length() == 0) return null;
+
+		HTMLPrinter.insertPageProlog(buffer, 0, getCSSStyles());
+		HTMLPrinter.addPageEpilog(buffer);
+		return buffer.toString();
+	}
+
+	public static String getELMessagesHoverInternal(String baseName, String propertyName, List<XModelObject> objects) {
+		StringBuffer buffer= new StringBuffer();
+
+		if (propertyName != null && propertyName.length() > 0) 
+			buffer.append(MessageFormat.format(Messages.ELInfoHover_propertyName, 
+				propertyName));
+			
+		if (baseName != null && baseName.length() > 0)
+			buffer.append(MessageFormat.format(Messages.ELInfoHover_baseName, 
+					baseName));
+		
+		if (objects != null) {
+			boolean firstValue = true;
+			for (XModelObject o : objects) {
+				IFile propFile = (IFile)o.getAdapter(IFile.class);
+				String propFilePath = null;
+				if (propFile != null) {
+					propFilePath = propFile.getFullPath().toString();
+				} else {
+					XModelObject parent = o.getFileType() == XModelObject.FILE ? o : o.getParent();
+					String path = parent.getPath();
+					while (parent != null && parent.getFileType() != XModelObject.SYSTEM) {
+						parent = parent.getParent();
+					}
+					if (parent instanceof JarSystemImpl) {
+						String sysPath = parent.getPath();
+						path = path.substring(sysPath.length());
+	
+						String jarPath = ((JarSystemImpl) parent).getLocation();
+						
+						IResource jar = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(new Path(jarPath));
+						
+						if (jar != null) {
+							jarPath = jar.getFullPath().toString();
+						}
+						
+						propFilePath = jarPath + "!" + path; //$NON-NLS-1$
+					}
+				}
+				buffer.append(Messages.ELInfoHover_newLine);
+				if (!firstValue) buffer.append(Messages.ELInfoHover_newLine);
+				else firstValue = false;
+				
+				buffer.append(MessageFormat.format(Messages.ELInfoHover_resourceBundle, 
+						propFilePath != null ? propFilePath : Messages.ELInfoHover_resourceBundleNotDefined));
+				
+				if (propertyName != null) {
+					String value = o.get("VALUE");  //$NON-NLS-1$
+					boolean addCut = false;
+					if (value != null) {
+						if (value.length() > 100) {
+							// Get first words of value
+							int lastSpace = value.lastIndexOf(' ', 99);
+							if (lastSpace != -1) {
+								value = value.substring(0, lastSpace);
+							} else { // cut as is
+								value = value.substring(0, 100);
+							}
+							addCut = true;
+						}
+					}
+					buffer.append(Messages.ELInfoHover_newLine);
+					buffer.append(MessageFormat.format(Messages.ELInfoHover_resourceBundlePropertyValue, 
+							value != null ? value : Messages.ELInfoHover_resourceBundlePropertyValueNotDefined,
+									addCut ? Messages.ELInfoHover_treeDots : "")); //$NON-NLS-1$
+				}
+			}
+		}
+
+		return buffer.length() == 0 ? null : buffer.toString();
+	}
+
+	
+	private static final String[] PROTOCOLS = {
+		JavaElementLinks.JAVADOC_VIEW_SCHEME,
+		JavaElementLinks.JAVADOC_SCHEME,
+		JavaElementLinks.OPEN_LINK_SCHEME,
+		"http", //$NON-NLS-1$
+		"https" //$NON-NLS-1$
+	};
+	
+	protected static String processLinks(String html) {
+		if (html == null)
+			return ""; //$NON-NLS-1$
+		String text;
+		try {
+			HTMLAnchorProcessor reader= new HTMLAnchorProcessor(new StringReader(html), PROTOCOLS);
+			text= reader.getString();
+			reader.close();
+		} catch (IOException e) {
+			text= ""; //$NON-NLS-1$
+		}
+		return text;
+	}
+
+	private static String fCSSStyles;
+	
+	/**
+	 * Returns the style information for displaying HTML content.
+	 *
+	 * @return the CSS styles
+	 */
+	private static String getCSSStyles() {
+		if (fCSSStyles == null) {
+			Bundle bundle= Platform.getBundle(ElUiPlugin.PLUGIN_ID);
+			URL url= bundle.getEntry("/resources/css/ELInfoHoverStyleSheet.css"); //$NON-NLS-1$
+			if (url != null) {
+				BufferedReader reader= null;
+				try {
+					url= FileLocator.toFileURL(url);
+					reader= new BufferedReader(new InputStreamReader(url.openStream()));
+					StringBuilder buffer= new StringBuilder(200);
+					String line= reader.readLine();
+					while (line != null) {
+						buffer.append(line);
+						buffer.append('\n');
+						line= reader.readLine();
+					}
+					fCSSStyles= buffer.toString();
+				} catch (IOException ex) {
+					ElUiPlugin.getDefault().logError(ex);
+				} finally {
+					try {
+						if (reader != null)
+							reader.close();
+					} catch (IOException e) {
+					}
+				}
+
+			}
+		}
+		String css= fCSSStyles;
+		if (css != null) {
+			FontData fontData= JFaceResources.getFontRegistry().getFontData(JFaceResources.DIALOG_FONT)[0];
+			css= HTMLPrinter.convertTopLevelFont(css, fontData);
+		}
+		return css;
+	}
+
+	
+	/**
+	 * Hover control creator.
+	 */
+	public static final class HoverControlCreator extends AbstractReusableInformationControlCreator {
+		/**
+		 * The information presenter control creator.
+		 */
+		private final IInformationControlCreator fInformationPresenterControlCreator;
+		private String fAffordance = null;
+
+		/**
+		 * @param informationPresenterControlCreator control creator for enriched hover
+		 */
+		public HoverControlCreator(IInformationControlCreator informationPresenterControlCreator, String affordance) {
+			fInformationPresenterControlCreator= informationPresenterControlCreator;
+			fAffordance = affordance;
+		}
+
+		/*
+		 * @see org.eclipse.jdt.internal.ui.text.java.hover.AbstractReusableInformationControlCreator#doCreateInformationControl(org.eclipse.swt.widgets.Shell)
+		 */
+		@Override
+		public IInformationControl doCreateInformationControl(Shell parent) {
+			if (BrowserInformationControl.isAvailable(parent)) {
+				BrowserInformationControl iControl = new BrowserInformationControl(parent, null, 
+								fAffordance == null ? Messages.hover_affordance : fAffordance) {
+					/*
+					 * @see org.eclipse.jface.text.IInformationControlExtension5#getInformationPresenterControlCreator()
+					 */
+					@Override
+					public IInformationControlCreator getInformationPresenterControlCreator() {
+						return fInformationPresenterControlCreator;
+					}
+				};
+				addLinkListener(iControl);
+				return iControl;
+			} else {
+				return new DefaultInformationControl(parent, fAffordance == null ? Messages.hover_affordance : fAffordance);
+			}
+		}
+
+		/*
+		 * @see org.eclipse.jdt.internal.ui.text.java.hover.AbstractReusableInformationControlCreator#canReuse(org.eclipse.jface.text.IInformationControl)
+		 */
+		@Override
+		public boolean canReuse(IInformationControl control) {
+			if (!super.canReuse(control))
+				return false;
+
+			if (control instanceof IInformationControlExtension4) {
+				((IInformationControlExtension4)control).setStatusText(fAffordance == null ? Messages.hover_affordance : fAffordance);
+			}
+
+			return true;
+		}
+	}
+
+	
+	/**
+	 * Presenter control creator.
+	 */
+	public static final class PresenterControlCreator extends AbstractReusableInformationControlCreator {
+		private final IWorkbenchSite fSite;
+
+		/**
+		 * Creates a new PresenterControlCreator.
+		 * 
+		 * @param site the site or <code>null</code> if none
+		 */
+		public PresenterControlCreator(IWorkbenchSite site) {
+			fSite= site;
+		}
+
+		/*
+		 * @see org.eclipse.jdt.internal.ui.text.java.hover.AbstractReusableInformationControlCreator#doCreateInformationControl(org.eclipse.swt.widgets.Shell)
+		 */
+		@Override
+		public IInformationControl doCreateInformationControl(Shell parent) {
+			if (BrowserInformationControl.isAvailable(parent)) {
+				ToolBarManager tbm= new ToolBarManager(SWT.FLAT);
+				BrowserInformationControl iControl= new BrowserInformationControl(parent, null, tbm);
+
+				final BackAction backAction= new BackAction(iControl);
+				backAction.setEnabled(false);
+				tbm.add(backAction);
+				final ForwardAction forwardAction= new ForwardAction(iControl);
+				tbm.add(forwardAction);
+				forwardAction.setEnabled(false);
+
+				final ShowInJavadocViewAction showInJavadocViewAction= new ShowInJavadocViewAction(iControl);
+				tbm.add(showInJavadocViewAction);
+				final OpenDeclarationAction openDeclarationAction= new OpenDeclarationAction(iControl);
+				tbm.add(openDeclarationAction);
+
+				final SimpleSelectionProvider selectionProvider= new SimpleSelectionProvider();
+				if (fSite != null) {
+					OpenAttachedJavadocAction openAttachedJavadocAction= new OpenAttachedJavadocAction(fSite);
+					openAttachedJavadocAction.setSpecialSelectionProvider(selectionProvider);
+					openAttachedJavadocAction.setImageDescriptor(JavaPluginImages.DESC_ELCL_OPEN_BROWSER);
+					openAttachedJavadocAction.setDisabledImageDescriptor(JavaPluginImages.DESC_DLCL_OPEN_BROWSER);
+					selectionProvider.addSelectionChangedListener(openAttachedJavadocAction);
+					selectionProvider.setSelection(new StructuredSelection());
+					tbm.add(openAttachedJavadocAction);
+				}
+				
+				IInputChangedListener inputChangeListener= new IInputChangedListener() {
+					public void inputChanged(Object newInput) {
+						backAction.update();
+						forwardAction.update();
+						if (newInput == null) {
+							selectionProvider.setSelection(new StructuredSelection());
+						} else if (newInput instanceof BrowserInformationControlInput) {
+							BrowserInformationControlInput input= (BrowserInformationControlInput) newInput;
+							Object inputElement= input.getInputElement();
+							selectionProvider.setSelection(new StructuredSelection(inputElement));
+							boolean isJavaElementInput= inputElement instanceof IJavaElement;
+							showInJavadocViewAction.setEnabled(isJavaElementInput);
+							openDeclarationAction.setEnabled(isJavaElementInput);
+						}
+					}
+				};
+				iControl.addInputChangeListener(inputChangeListener);
+
+				tbm.update(true);
+
+				addLinkListener(iControl);
+				return iControl;
+
+			} else {
+				return new DefaultInformationControl(parent, true);
+			}
+		}
+	}
+
+	private static void addLinkListener(final BrowserInformationControl control) {
+		control.addLocationListener(new LocationListener() {
+			@Override
+			public void changing(LocationEvent event) {
+				String loc= event.location;
+
+				if ("about:blank".equals(loc)) { //$NON-NLS-1$
+					return;
+				}
+
+				event.doit= false;
+
+				if (loc.startsWith("about:")) { //$NON-NLS-1$
+					// Relative links should be handled via head > base tag.
+					// If no base is available, links just won't work.
+					return;
+				}
+
+				URI uri= null;
+				try {
+					uri= new URI(loc);
+				} catch (URISyntaxException e) {
+					ElUiPlugin.getDefault().logError(e);
+					return;
+				}
+
+				String scheme= uri == null ? null : uri.getScheme();
+				if (JavaElementLinks.JAVADOC_VIEW_SCHEME.equals(scheme)) {
+					IJavaElement linkTarget= JavaElementLinks.parseURI(uri);
+					if (linkTarget == null)
+						return;
+
+					handleJavadocViewLink(linkTarget);
+				} else if (JavaElementLinks.JAVADOC_SCHEME.equals(scheme)) {
+					IJavaElement linkTarget= JavaElementLinks.parseURI(uri);
+					if (linkTarget == null)
+						return;
+
+					handleInlineJavadocLink(linkTarget);
+				} else if (JavaElementLinks.OPEN_LINK_SCHEME.equals(scheme)) {
+					IJavaElement linkTarget= JavaElementLinks.parseURI(uri);
+					if (linkTarget == null)
+						return;
+
+					handleDeclarationLink(linkTarget);
+				} else if (scheme != null && (scheme.toLowerCase().equalsIgnoreCase("http") || //$NON-NLS-1$
+						scheme.toLowerCase().equalsIgnoreCase("https"))) { //$NON-NLS-1$
+					try {
+						if (handleExternalLink(new URL(loc), event.display, true))
+							return;
+	
+						event.doit= true;
+					} catch (MalformedURLException e) {
+						ElUiPlugin.getDefault().logError(e);
+					}
+				}
+			}
+
+			/* (non-Javadoc)
+			 * @see org.eclipse.jdt.internal.ui.viewsupport.JavaElementLinks.ILinkHandler#handleJavadocViewLink(org.eclipse.jdt.core.IJavaElement)
+			 */
+			public void handleJavadocViewLink(IJavaElement linkTarget) {
+				control.notifyDelayedInputChange(null);
+				control.setVisible(false);
+				control.dispose();
+				try {
+					JavadocView view= (JavadocView) JavaPlugin.getActivePage().showView(JavaUI.ID_JAVADOC_VIEW);
+					view.setInput(linkTarget);
+				} catch (PartInitException e) {
+					ElUiPlugin.getDefault().logError(e);
+				}
+			}
+
+			/* (non-Javadoc)
+			 * @see org.eclipse.jdt.internal.ui.viewsupport.JavaElementLinks.ILinkHandler#handleInlineJavadocLink(org.eclipse.jdt.core.IJavaElement)
+			 */
+			public void handleInlineJavadocLink(IJavaElement linkTarget) {
+				JavadocBrowserInformationControlInput hoverInfo= JavadocHover.getHoverInfo(new IJavaElement[] { linkTarget }, null, null, (JavadocBrowserInformationControlInput) control.getInput());
+				if (control.hasDelayedInputChangeListener())
+					control.notifyDelayedInputChange(hoverInfo);
+				else
+					control.setInput(hoverInfo);
+			}
+
+			/* (non-Javadoc)
+			 * @see org.eclipse.jdt.internal.ui.viewsupport.JavaElementLinks.ILinkHandler#handleDeclarationLink(org.eclipse.jdt.core.IJavaElement)
+			 */
+			public void handleDeclarationLink(IJavaElement linkTarget) {
+				control.notifyDelayedInputChange(null);
+				control.dispose(); //FIXME: should have protocol to hide, rather than dispose
+				try {
+					JavadocHover.openDeclaration(linkTarget);
+				} catch (PartInitException e) {
+					ElUiPlugin.getDefault().logError(e);
+				} catch (JavaModelException e) {
+					ElUiPlugin.getDefault().logError(e);
+				}
+			}
+
+			boolean handleExternalLink(URL url, Display display, boolean openInExternalBrowser) {
+				control.notifyDelayedInputChange(null);
+				control.dispose();
+
+				// Open attached Javadoc links
+				if (openInExternalBrowser)
+					OpenBrowserUtil.openExternal(url, display);
+				else 
+					OpenBrowserUtil.open(url, display);
+				
+				return true;
+			}
+
+			public void changed(LocationEvent event) {
+			}
+		});
+	}
+
+	/**
+	 * Action to go back to the previous input in the hover control.
+	 *
+	 * @since 3.4
+	 */
+	private static final class BackAction extends Action {
+		private final BrowserInformationControl fInfoControl;
+
+		public BackAction(BrowserInformationControl infoControl) {
+			fInfoControl= infoControl;
+			setText(Messages.ELInfoHover_back);
+			ISharedImages images= PlatformUI.getWorkbench().getSharedImages();
+			setImageDescriptor(images.getImageDescriptor(ISharedImages.IMG_TOOL_BACK));
+			setDisabledImageDescriptor(images.getImageDescriptor(ISharedImages.IMG_TOOL_BACK_DISABLED));
+
+			update();
+		}
+
+		@Override
+		public void run() {
+			BrowserInformationControlInput previous= (BrowserInformationControlInput) fInfoControl.getInput().getPrevious();
+			if (previous != null) {
+				fInfoControl.setInput(previous);
+			}
+		}
+
+		public void update() {
+			BrowserInformationControlInput current= fInfoControl.getInput();
+
+			if (current != null && current.getPrevious() != null) {
+				BrowserInput previous= current.getPrevious();
+				setToolTipText(org.eclipse.jdt.internal.corext.util.Messages.format(Messages.ELInfoHover_back_toElement_toolTip, BasicElementLabels.getJavaElementName(previous.getInputName())));
+				setEnabled(true);
+			} else {
+				setToolTipText(Messages.ELInfoHover_back);
+				setEnabled(false);
+			}
+		}
+	}
+
+	/**
+	 * Action to go forward to the next input in the hover control.
+	 *
+	 * @since 3.4
+	 */
+	private static final class ForwardAction extends Action {
+		private final BrowserInformationControl fInfoControl;
+
+		public ForwardAction(BrowserInformationControl infoControl) {
+			fInfoControl= infoControl;
+			setText(Messages.ELInfoHover_forward);
+			ISharedImages images= PlatformUI.getWorkbench().getSharedImages();
+			setImageDescriptor(images.getImageDescriptor(ISharedImages.IMG_TOOL_FORWARD));
+			setDisabledImageDescriptor(images.getImageDescriptor(ISharedImages.IMG_TOOL_FORWARD_DISABLED));
+
+			update();
+		}
+
+		@Override
+		public void run() {
+			BrowserInformationControlInput next= (BrowserInformationControlInput) fInfoControl.getInput().getNext();
+			if (next != null) {
+				fInfoControl.setInput(next);
+			}
+		}
+
+		public void update() {
+			BrowserInformationControlInput current= fInfoControl.getInput();
+
+			if (current != null && current.getNext() != null) {
+				setToolTipText(org.eclipse.jdt.internal.corext.util.Messages.format(Messages.ELInfoHover_forward_toElement_toolTip, BasicElementLabels.getJavaElementName(current.getNext().getInputName())));
+				setEnabled(true);
+			} else {
+				setToolTipText(Messages.ELInfoHover_forward_toolTip);
+				setEnabled(false);
+			}
+		}
+	}
+
+	/**
+	 * Action that shows the current hover contents in the Javadoc view.
+	 *
+	 * @since 3.4
+	 */
+	private static final class ShowInJavadocViewAction extends Action {
+		private final BrowserInformationControl fInfoControl;
+
+		public ShowInJavadocViewAction(BrowserInformationControl infoControl) {
+			fInfoControl= infoControl;
+			setText(Messages.ELInfoHover_showInJavadoc);
+			setImageDescriptor(JavaPluginImages.DESC_OBJS_JAVADOCTAG); //TODO: better image
+		}
+
+		/*
+		 * @see org.eclipse.jface.action.Action#run()
+		 */
+		@Override
+		public void run() {
+			JavadocBrowserInformationControlInput infoInput= (JavadocBrowserInformationControlInput) fInfoControl.getInput(); //TODO: check cast
+			fInfoControl.notifyDelayedInputChange(null);
+			fInfoControl.dispose(); //FIXME: should have protocol to hide, rather than dispose
+			try {
+				JavadocView view= (JavadocView) JavaPlugin.getActivePage().showView(JavaUI.ID_JAVADOC_VIEW);
+				view.setInput(infoInput);
+			} catch (PartInitException e) {
+				ElUiPlugin.getDefault().logError(e);
+			}
+		}
+	}
+
+	/**
+	 * Action that opens the current hover input element.
+	 *
+	 * @since 3.4
+	 */
+	private static final class OpenDeclarationAction extends Action {
+		private final BrowserInformationControl fInfoControl;
+
+		public OpenDeclarationAction(BrowserInformationControl infoControl) {
+			fInfoControl= infoControl;
+			setText(Messages.ELInfoHover_openDeclaration);
+			JavaPluginImages.setLocalImageDescriptors(this, "goto_input.gif"); //$NON-NLS-1$ //TODO: better images
+		}
+
+		/*
+		 * @see org.eclipse.jface.action.Action#run()
+		 */
+		@Override
+		public void run() {
+			JavadocBrowserInformationControlInput infoInput= (JavadocBrowserInformationControlInput) fInfoControl.getInput(); //TODO: check cast
+			fInfoControl.notifyDelayedInputChange(null);
+			fInfoControl.dispose(); //FIXME: should have protocol to hide, rather than dispose
+
+			try {
+				JavadocHover.openDeclaration(infoInput.getElement());
+			} catch (PartInitException e) {
+				ElUiPlugin.getDefault().logError(e);
+			} catch (JavaModelException e) {
+				ElUiPlugin.getDefault().logError(e);
+			}
+		}
+	}
+}

--- a/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/internal/info/HTMLAnchorProcessor.java
+++ b/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/internal/info/HTMLAnchorProcessor.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.common.el.ui.internal.info;
+
+import java.io.IOException;
+import java.io.PushbackReader;
+import java.io.Reader;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jface.internal.text.html.SubstitutionTextReader;
+
+/**
+ * Excludes anchors with unknown protocol schema in 'href' attributes
+ * 
+ * @author Victor V. Rubezhny
+ *
+ */
+public class HTMLAnchorProcessor extends SubstitutionTextReader {
+	private static final String EMPTY_STRING= ""; //$NON-NLS-1$
+
+	Set<String> fEnabledProtocols = new HashSet<String>(2);
+	private boolean fIgnoredAnchor= false;
+	
+	public HTMLAnchorProcessor(Reader reader, String[] enabledProtocols) {
+		super(new PushbackReader(reader));
+		if (enabledProtocols != null) {
+			for (String p : enabledProtocols) {
+				if (p != null && p.trim().length() > 0)
+					fEnabledProtocols.add(p.trim().toLowerCase());
+			}
+		}
+	}
+
+	@Override
+	protected String computeSubstitution(int c) throws IOException {
+		if (c == '<')
+			return  processHTMLTag();
+
+		return null;
+	}
+
+	/*
+	 * A '<' has been read. Process a html tag
+	 */
+	private String processHTMLTag() throws IOException {
+
+		StringBuffer buf= new StringBuffer();
+		int ch;
+		do {
+
+			ch= nextChar();
+
+			while (ch != -1 && ch != '>') {
+				buf.append((char) ch);
+				ch= nextChar();
+				if (ch == '"'){
+					buf.append((char) ch);
+					ch= nextChar();
+					while (ch != -1 && ch != '"'){
+						buf.append((char) ch);
+						ch= nextChar();
+					}
+				}
+				if (ch == '<' && !isInComment(buf)) {
+					unread(ch);
+					return '<' + buf.toString();
+				}
+			}
+
+			if (ch == -1)
+				return null;
+
+			if (!isInComment(buf) || isCommentEnd(buf)) {
+				break;
+			}
+			// unfinished comment
+			buf.append((char) ch);
+		} while (true);
+
+		return internalProcessTag(buf.toString());
+	}
+	
+	private void unread(int ch) throws IOException {
+		((PushbackReader) getReader()).unread(ch);
+	}
+	
+	private static boolean isInComment(StringBuffer buf) {
+		return buf.length() >= 3 && "!--".equals(buf.substring(0, 3)); //$NON-NLS-1$
+	}
+
+	private static boolean isCommentEnd(StringBuffer buf) {
+		int tagLen= buf.length();
+		return tagLen >= 5 && "--".equals(buf.substring(tagLen - 2)); //$NON-NLS-1$
+	}
+	
+	private String internalProcessTag(String tagText) {
+
+		if (tagText == null || tagText.length() == 0)
+			return EMPTY_STRING;
+
+		String html= tagText.toLowerCase();
+
+		String tag= html;
+		if ('/' == tag.charAt(0))
+			tag= tag.substring(1);
+
+		if ("a".equals(html) || (html.length() > 2 && html.startsWith("a") && Character.isWhitespace(html.charAt(1)))) { //$NON-NLS-1$ $NON-NLS-2$
+			return startAnchor(html) ? EMPTY_STRING : '<' + tagText + '>';
+		}
+
+		if ("/a".equals(html)) { //$NON-NLS-1$
+			return stopAnchor() ? EMPTY_STRING : '<' + tagText + '>';
+		}
+		
+		return '<' + tagText + '>';
+	}
+	
+	private boolean startAnchor(String html) {
+		fIgnoredAnchor = true;
+		int hrefStart = html.indexOf("href"); //$NON-NLS-1$
+		if (hrefStart != -1) {
+			int equalStart = html.indexOf('=', hrefStart);
+			if (equalStart != -1) {
+				if ("href".equals(html.substring(hrefStart, equalStart).trim())) {
+					int valueStart = equalStart + 1;
+					while (valueStart < html.length() && !Character.isLetterOrDigit(html.charAt(valueStart)) &&
+							('"' == html.charAt(valueStart) || '\'' == html.charAt(valueStart) || 
+								Character.isWhitespace(html.charAt(valueStart)))) {
+						valueStart++;
+					}
+					int end = html.indexOf(':', valueStart);
+					if (end != -1) {
+						String prot = html.substring(valueStart, end);
+						fIgnoredAnchor = !fEnabledProtocols.contains(prot);
+					}
+				}
+			}
+		}
+		return fIgnoredAnchor;
+	}
+	
+	private boolean stopAnchor() {
+		boolean result = fIgnoredAnchor;
+		if (fIgnoredAnchor) {
+			fIgnoredAnchor = false;
+		}
+		return result;
+	}
+}

--- a/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/internal/info/Messages.java
+++ b/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/internal/info/Messages.java
@@ -1,0 +1,52 @@
+/******************************************************************************* 
+ * Copyright (c) 2011-2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.common.el.ui.internal.info;
+
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * 
+ * @author jeremy
+ *
+ */
+public class Messages  extends NLS {
+
+	private static final String BUNDLE_NAME = "org.jboss.tools.common.el.ui.internal.info.messages";//$NON-NLS-1$
+
+	private Messages() {
+		// Do not instantiate
+	}
+
+	static {
+		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+	}
+
+	public static String NO_JAVADOC;
+	public static String hover_affordance;
+	public static String additionalInfo_affordance;
+	
+	public static String ELInfoHover_back;
+	public static String ELInfoHover_back_toElement_toolTip;
+	public static String ELInfoHover_forward;
+	public static String ELInfoHover_forward_toElement_toolTip;
+	public static String ELInfoHover_forward_toolTip;
+	public static String ELInfoHover_openDeclaration;
+	public static String ELInfoHover_showInJavadoc;
+	
+	public static String ELInfoHover_baseName; 
+	public static String ELInfoHover_propertyName;
+	public static String ELInfoHover_resourceBundle; 
+	public static String ELInfoHover_resourceBundlePropertyValue;
+	public static String ELInfoHover_resourceBundlePropertyValueNotDefined; 
+	public static String ELInfoHover_resourceBundleNotDefined;
+	public static String ELInfoHover_newLine;
+	public static String ELInfoHover_treeDots;
+}

--- a/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/internal/info/messages.properties
+++ b/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/internal/info/messages.properties
@@ -1,0 +1,19 @@
+NO_JAVADOC=No Javadoc could be found<br>
+hover_affordance=Press 'F2' for focus
+additionalInfo_affordance=Press 'Tab' from proposal table or click for focus
+ELInfoHover_back=Back
+ELInfoHover_back_toElement_toolTip=Back to {0}
+ELInfoHover_forward=Forward
+ELInfoHover_forward_toElement_toolTip=Forward to {0}
+ELInfoHover_forward_toolTip=Forward
+ELInfoHover_openDeclaration=Open Declaration
+ELInfoHover_showInJavadoc=Show in Javadoc View
+
+ELInfoHover_baseName=<b>Base Name:</b> {0}<br>
+ELInfoHover_propertyName=<b>Property:</b> {0}<br>
+ELInfoHover_resourceBundle=<b>Resource Bundle:</b> {0}
+ELInfoHover_resourceBundlePropertyValue=<b>Value:</b> {0}{1}
+ELInfoHover_resourceBundlePropertyValueNotDefined=[Value not defined]
+ELInfoHover_resourceBundleNotDefined=[Resource Bundle not defined]
+ELInfoHover_newLine=<br>
+ELInfoHover_treeDots=...


### PR DESCRIPTION
...itional Info window to support URLs.

Content Assist Additional Infos and Tooltips (Hovers) were made to be like in Java Content Assist (Support links, Back/Forward/Open actions, icons and so on)
The new look works equally in JST editors and in Java Editor (for EL in Java Strings).
The following JUnit Tests were updated (in another PR) for the changes made to CA Add. Info's and Tooltip's (Hover's) content:
org.jboss.tools.jsf.jsp.ca.test.CAForELJavaAndJSTCompareTest
org.jboss.tools.jsf.jsp.ca.test.CAJsfAddInfoInELMessagesTest
org.jboss.tools.jsf.jsp.hover.ELTooltipTest

Signed-off-by: vrubezhny vrubezhny@exadel.com
