### PR TITLE
JBIDE-16162 - org.jboss.tools.common.mylyn includes itself as a dependency

### DIFF
--- a/common/plugins/org.jboss.tools.common.mylyn/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.mylyn/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.common.mylyn;singleton:=true
 Bundle-Version: 3.6.0.qualifier
 Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.jboss.tools.common.mylyn,
- org.eclipse.mylyn.commons.core;bundle-version="[3.8.0,4.0.0)",
+Require-Bundle: org.eclipse.mylyn.commons.core;bundle-version="[3.8.0,4.0.0)",
  org.eclipse.mylyn.commons.ui;bundle-version="[3.8.0,4.0.0)",
  org.eclipse.mylyn.tasks.core;bundle-version="[3.8.0,4.0.0)",
  org.eclipse.mylyn.tasks.ui;bundle-version="[3.8.0,4.0.0)",


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-16162
org.jboss.tools.common.mylyn includes itself as a dependency
