### PR TITLE
JBIDE-16176 : use proper stacks archetype id during lookup

### DIFF
--- a/stacks/plugins/org.jboss.tools.stacks.core/src/org/jboss/tools/stacks/core/model/StacksUtil.java
+++ b/stacks/plugins/org.jboss.tools.stacks.core/src/org/jboss/tools/stacks/core/model/StacksUtil.java
@@ -56,13 +56,16 @@ public class StacksUtil {
 		// no need for public constructor
 	}
 
+	/**
+	 * Returns the Archetype matching a given stacks archetype id
+	 */
 	public static Archetype getArchetype(String archetypeId, Stacks fromStacks) {
 		if (fromStacks == null || archetypeId == null) {
 			return null;
 		}
 
 		for (Archetype a : fromStacks.getAvailableArchetypes()) {
-			if (archetypeId.equals(a.getArtifactId())) {
+			if (archetypeId.equals(a.getId())) {
 				return a;
 			}
 		}


### PR DESCRIPTION
Commit also needs to be applied to jbosstools-4.1.1.x and master

Signed-off-by: Fred Bricon fbricon@gmail.com
