### PR TITLE
JBIDE-8445 Do not create markers at internal attribute validation by XModel

### DIFF
--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/AbstractExtendedXMLFileImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/AbstractExtendedXMLFileImpl.java
@@ -278,7 +278,9 @@ public class AbstractExtendedXMLFileImpl extends AbstractXMLFileImpl {
     }
    
     public void check() {
-    	constraintChecker.check();
+    	if(!isOverlapped()) {
+    		constraintChecker.check();
+    	}
     }
     
     protected void safeChangeTimeStamp() {


### PR DESCRIPTION
Errors are saved into internal objects and are available
only for JBoss Tools XML editor.

Changes are covered by existing tests,
for instance SeamXMLModelTest.testDebugAttribute().
