### PR TITLE
JBIDE-16254 common.model.test plugin stuck in Display.sleep() on hudson

### DIFF
--- a/tests/plugins/org.jboss.tools.tests/src/org/jboss/tools/test/util/JobUtils.java
+++ b/tests/plugins/org.jboss.tools.tests/src/org/jboss/tools/test/util/JobUtils.java
@@ -13,6 +13,7 @@ package org.jboss.tools.test.util;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
+import org.jboss.tools.test.util.xpl.DisplayDelayHelper;
 
 /**
  * @author eskimo
@@ -77,12 +78,8 @@ public class JobUtils {
 	public static void delay(long waitTimeMillis) {
 		Display display = Display.getCurrent();
 		if(PlatformUI.isWorkbenchRunning() && display!= null) {
-			long endTimeMillis = System.currentTimeMillis() + waitTimeMillis;
-			while (System.currentTimeMillis() < endTimeMillis) {
-				if (!display.readAndDispatch())
-					display.sleep();
-			}
-			display.update();
+			DisplayDelayHelper delay = new DisplayDelayHelper(waitTimeMillis);
+			delay.waitForCondition(display, waitTimeMillis);
 		} else { // Otherwise, perform a simple sleep.
 			try {
 				Thread.sleep(waitTimeMillis);

--- a/tests/plugins/org.jboss.tools.tests/src/org/jboss/tools/test/util/xpl/DisplayDelayHelper.java
+++ b/tests/plugins/org.jboss.tools.tests/src/org/jboss/tools/test/util/xpl/DisplayDelayHelper.java
@@ -1,0 +1,21 @@
+package org.jboss.tools.test.util.xpl;
+
+import org.eclipse.core.runtime.jobs.Job;
+
+public class DisplayDelayHelper extends DisplayHelper {
+	
+	private long currentTime;
+	private long delay;
+
+	public DisplayDelayHelper(long delay) {
+		super();
+		this.currentTime = System.currentTimeMillis();
+		this.delay = delay;
+	}
+
+	@Override
+	protected boolean condition() {
+		return System.currentTimeMillis() > currentTime+delay;
+	}
+
+}


### PR DESCRIPTION
Refactored delay to use Display.sleep() and Display.wake() to avoid
scenarios where display sleeps forever
