### PR TITLE
JBIDE-16428 o.j.t.test.util.JobUtils.waitForIdle() always waits for maxI...

### DIFF
--- a/tests/plugins/org.jboss.tools.tests/src/org/jboss/tools/test/util/JobUtils.java
+++ b/tests/plugins/org.jboss.tools.tests/src/org/jboss/tools/test/util/JobUtils.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2007-2013 Red Hat, Inc. 
+ * Copyright (c) 2007-2014 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -34,7 +34,7 @@ public class JobUtils {
 
 	public static void waitForIdle(long delay, long maxIdle) {
 		long start = System.currentTimeMillis();
-		while (!Job.getJobManager().isIdle()) {
+		while (!isIdle()) {
 			delay(delay);
 			if ((System.currentTimeMillis() - start) > maxIdle) {
 				Job[] jobs = Job.getJobManager().find(null);
@@ -50,6 +50,19 @@ public class JobUtils {
 							"Long running tasks detected:" + str.toString()); //$NON-NLS-1$
 			}
 		}
+	}
+	
+	private static boolean isIdle() {
+		boolean isIdle = Job.getJobManager().isIdle();
+		if (!isIdle) {
+			Job[] jobs = Job.getJobManager().find(null);
+			for (Job job : jobs) {
+				if (job.getThread() != null && !shouldIgnoreJob(job)) {
+					return false;
+				}
+			}
+		}
+		return true;
 	}
 
 	// The list of non-build related long running jobs


### PR DESCRIPTION
...dle timeout expiration even if only ignored jobs returned by JobManager

JobUtils.waitForIdle is made not to wait in case the only ignored jobs present in JobManager

Signed-off-by: vrubezhny vrubezhny@exadel.com
