### PR TITLE
JBIDE-16482 web.xml file of JSF project with Servlet version 3.1 is not opened with JBT XML editor

### DIFF
--- a/common/plugins/org.jboss.tools.common.model.ui/plugin.xml
+++ b/common/plugins/org.jboss.tools.common.model.ui/plugin.xml
@@ -32,6 +32,7 @@
          <contentTypeBinding contentTypeId="org.eclipse.jst.j2ee.webDD"/>
          <contentTypeBinding contentTypeId="org.eclipse.jst.jee.ee5webDD"/>
          <contentTypeBinding contentTypeId="org.eclipse.jst.jee.ee6webDD"/>
+         <contentTypeBinding contentTypeId="org.eclipse.jst.jee.ee7webDD"/>
 
          <contentTypeBinding contentTypeId="org.jboss.tools.common.model.ui.xml"/>
          <contentTypeBinding contentTypeId="org.eclipse.jst.jsf.facesconfig.facesConfigFile"/>


### PR DESCRIPTION
New content type 'org.eclipse.jst.jee.ee7webDD'
is registered for JBoss Tools XML editor.
