### PR TITLE
JBIDE-17165 jQuery Mobile Palette 1.3 still have HTML 5 items

### DIFF
--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/options/SharableConstants.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/options/SharableConstants.java
@@ -32,6 +32,7 @@ public interface SharableConstants {
 
 	public String ATTR_HIDDEN = "hidden"; //$NON-NLS-1$
 
+	public String PALETTE_ROOT = "Palette"; //$NON-NLS-1$
 	public String MOBILE_PALETTE_ROOT = "Mobile"; //$NON-NLS-1$
 	public String PALETTE_GROUP = "group"; //$NON-NLS-1$
 

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/options/impl/XStudioDataLoaderImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/options/impl/XStudioDataLoaderImpl.java
@@ -19,12 +19,14 @@ import java.io.Reader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.text.MessageFormat;
+
 import org.w3c.dom.*;
 import org.eclipse.core.runtime.Platform;
 import org.jboss.tools.common.model.*;
 import org.jboss.tools.common.model.options.*;
 import org.jboss.tools.common.model.plugin.ModelPlugin;
 import org.jboss.tools.common.model.util.*;
+import org.jboss.tools.common.xml.XMLUtilities;
 import org.osgi.framework.Bundle;
 
 public class XStudioDataLoaderImpl implements SharableConstants {
@@ -160,6 +162,9 @@ public class XStudioDataLoaderImpl implements SharableConstants {
         if(x == null || x.getLength() == 0) return;
 		Element xs = (Element)x.item(0);
 		check(xs.getChildNodes(), names);
+
+		removeMobilePalette(xs);
+
         try {
             XModelObjectLoaderUtil.serialize(xs, f.getAbsolutePath());
         } catch (IOException e2) {
@@ -177,6 +182,20 @@ public class XStudioDataLoaderImpl implements SharableConstants {
     	for (int i = 0; i < names.length; i++)
     	  if(names[i].equals(n.getNodeName())) return;
     	 n.getParentNode().removeChild(n);
+    }
+
+    private void removeMobilePalette(Element xs) {
+    	Element p = XMLUtilities.getUniqueChild(xs, SharableConstants.PALETTE_ROOT);
+    	if(p != null) {
+    		NodeList nl = p.getChildNodes();    		
+    		for (int i = 0; i < nl.getLength(); i++) {
+    			Node n = nl.item(i);
+    			if(n instanceof Element && SharableConstants.MOBILE_PALETTE_ROOT.equals(((Element)n).getAttribute(XModelObjectConstants.XML_ATTR_NAME))) {
+    				p.removeChild(n);
+    				break;
+    			}
+    		}
+    	}
     }
 
     private void mergeGeneralToProject(SharableElementImpl object, boolean merge_all) {


### PR DESCRIPTION
Do not save Mobile palette which is read-only with
editable JSF palette. When saved it keeps items that
might be removed in new versions of JBoss Tools.
