### PR TITLE
JBIDE-17148 api enhancement for url transport utility class

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/ecf/URLTransportUtility.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/ecf/URLTransportUtility.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.net.URL;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -62,6 +63,29 @@ public class URLTransportUtility {
 	 */
 	public File getCachedFileForURL(String url, String displayName, int lifespan,
 			IProgressMonitor monitor) throws CoreException {
+		return getCachedFileForURL(url, displayName, lifespan, URLTransportCache.getDefault(), monitor);
+	}
+	
+	/**
+	 * Get a cached file for the given url. 
+	 * If a cached version does not yet exist, download one now.
+	 * 
+	 * @param url
+	 * @param displayName
+	 * @param lifespan
+	 * @param cacheRoot
+	 * @param monitor
+	 * @return
+	 * @throws CoreException
+	 */
+	public File getCachedFileForURL(String url, String displayName, int lifespan,
+			IPath cacheRoot, IProgressMonitor monitor) throws CoreException {
+		URLTransportCache cache = URLTransportCache.getCache(cacheRoot);
+		return getCachedFileForURL(url, displayName, lifespan, cache, monitor);
+	}
+	
+	private File getCachedFileForURL(String url, String displayName, int lifespan,
+			URLTransportCache cache, IProgressMonitor monitor) throws CoreException {
 		monitor.beginTask(displayName, 200);
 		IProgressMonitor sub1 = new SubProgressMonitor(monitor, 100);
 		if( URLTransportCache.getDefault().isCacheOutdated(url, sub1)) {


### PR DESCRIPTION
General structure of the change is that:
  1) A bug was fixed where caches were always incorrect. (String was not url-decoded on load)
  2) Cache indexes have been moved to a standalone index file for each cache
  3) The cached file name now more closely resembles the url it is for, rather than cache-324232432.tmp
  4) A new method signature is added to public API class URLTransportUtility where a cache root can be passed in. 
