### PR TITLE
JBIDE-17168 Test Failure on Windows: PropertiesLoaderTest

### DIFF
--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/loaders/impl/PropertiesLoader.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/loaders/impl/PropertiesLoader.java
@@ -124,7 +124,7 @@ public class PropertiesLoader implements XObjectLoader {
     					lineEnd.setLength(0);
                     } 
             	}
-				if(state != 2) sb.append(s); else lineEnd.append(s);
+				if(state != 2 && state != 4) sb.append(s); else lineEnd.append(s);
             	continue;
             } 
             if(s.equals("\n")) { //$NON-NLS-1$
@@ -132,6 +132,7 @@ public class PropertiesLoader implements XObjectLoader {
                 	if(state != 4) {
                 		sb.append(s);
                 	} else {
+                		lineEnd.append(s);
                 		state = 2;
                 	}
                 	if(state == 3) {


### PR DESCRIPTION
Logic for property loading is fixed.
