### PR TITLE
JBIDE-17219 NullPointerException when Template category selected in Project Properties Dialog

### DIFF
--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/templates/configuration/MetaConfigurationLoader.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/templates/configuration/MetaConfigurationLoader.java
@@ -53,8 +53,12 @@ public class MetaConfigurationLoader implements MetaTemplateConstants {
 	
 	public void loadProjectConfiguration(MetaConfiguration c, IProject project) {
 		Document document = getDocument(new Path(getProjectLocation(project)));
-		loadConfiguration(c, document);
-	}	
+		if(document != null) {
+			//Document is null when file PROJECT_FILE_NAME is missing in project
+			//because project configuration was not edited yet.
+			loadConfiguration(c, document);
+		}
+	}
 
 	public void saveGlobalConfiguration(MetaConfiguration c) {
 		Element element = XMLUtilities.createDocumentElement(META_TEMPLATE_GROUPS);

--- a/common/tests/org.jboss.tools.common.model.test/src/org/jboss/tools/common/model/test/CommonModelAllTests.java
+++ b/common/tests/org.jboss.tools.common.model.test/src/org/jboss/tools/common/model/test/CommonModelAllTests.java
@@ -39,6 +39,7 @@ public class CommonModelAllTests {
 		suite.addTestSuite(EclipseJavaUtilTest.class);
 		suite.addTestSuite(ResourceAdapterTest.class);
 		suite.addTestSuite(PaletteLoaderTest.class);
+		suite.addTestSuite(MetaConfigurationLoaderTest.class);
 
 		TestSuite annotationSuite = new TestSuite("Annotation Tests");
 		annotationSuite.addTestSuite(AnnotationTest.class);

--- a/common/tests/org.jboss.tools.common.model.test/src/org/jboss/tools/common/model/test/MetaConfigurationLoaderTest.java
+++ b/common/tests/org.jboss.tools.common.model.test/src/org/jboss/tools/common/model/test/MetaConfigurationLoaderTest.java
@@ -1,0 +1,44 @@
+/******************************************************************************* 
+ * Copyright (c) 2014 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.common.model.test;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.jboss.tools.common.model.ui.templates.configuration.MetaConfiguration;
+import org.jboss.tools.common.model.ui.templates.configuration.MetaConfigurationManager;
+import org.jboss.tools.test.util.JobUtils;
+import org.jboss.tools.test.util.TestProjectProvider;
+
+import junit.framework.TestCase;
+
+public class MetaConfigurationLoaderTest extends TestCase {
+	static String BUNDLE_NAME = "org.jboss.tools.common.model.test";
+	TestProjectProvider provider = null;
+	IProject project = null;
+
+	public MetaConfigurationLoaderTest() {}
+
+	public void setUp() throws Exception {
+		provider = new TestProjectProvider(BUNDLE_NAME, null, "Test1", true); 
+		project = provider.getProject();
+
+		project.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+		
+		JobUtils.waitForIdle();
+	}
+
+	public void testMetaConfigurationLoader() throws Exception {
+		MetaConfiguration c = MetaConfigurationManager.getInstance().getProjectConfiguration(project);
+		assertNotNull(c);
+	}
+	
+}


### PR DESCRIPTION
Checked null for the case when project templates are not
modified yet and file storing templates is missing in the project.
