### PR TITLE
JBDS-2996 - Runtime search messages written to stdout when a new runtime is added in JBDS8.beta1

### DIFF
--- a/runtime/plugins/org.jboss.tools.runtime.core/src/org/jboss/tools/runtime/core/extract/internal/UntarUtility.java
+++ b/runtime/plugins/org.jboss.tools.runtime.core/src/org/jboss/tools/runtime/core/extract/internal/UntarUtility.java
@@ -76,7 +76,6 @@ public class UntarUtility implements IExtractUtility {
 		TarEntry entry = zin.getNextEntry();
 		while (entry != null) {
 			String name = entry.getName();
-			System.out.println(name);
 			progress.subTask(NLS.bind("Uncompressing {0}", name));
 			if (archivePath != null && name.startsWith(archivePath)) {
 				name = name.substring(archivePath.length());
@@ -116,7 +115,6 @@ public class UntarUtility implements IExtractUtility {
 					}
 				}
 			}
-			System.out.println(possibleRoot);
 			
 			entry = zin.getNextEntry();
 		}


### PR DESCRIPTION
https://issues.jboss.org/browse/JBDS-2996
Runtime search messages written to stdout when a new runtime is added in JBDS8.beta1
