### PR TITLE
JBIDE-17272 - Compilation error in org.jboss.tools.common.jdt.debug

### DIFF
--- a/common/plugins/org.jboss.tools.common.jdt.debug/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.jdt.debug/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.7.100",
  org.eclipse.jdt.core;bundle-version="3.7.0",
  org.eclipse.debug.core;bundle-version="3.7.0",
- org.eclipse.jdt.launching;bundle-version="3.6.0"
+ org.eclipse.jdt.launching;bundle-version="3.6.0",
+ org.eclipse.jdt.debug;bundle-version="3.8.100"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: %BundleVendor


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-17272
Compilation error in org.jboss.tools.common.jdt.debug
