### PR TITLE
JBIDE-17294 As-you-type CDI validation doesnt work

### DIFF
--- a/common/plugins/org.jboss.tools.common.validation/plugin.xml
+++ b/common/plugins/org.jboss.tools.common.validation/plugin.xml
@@ -4,6 +4,11 @@
    <extension-point id="validator" name="KB Validator" schema="schema/validator.exsd"/>
    <extension-point id="warnings" name="Warning names supported by @SuppressWarnings" schema="schema/warnings.exsd"/>
  
+   <extension point="org.eclipse.ui.startup" >
+	   <startup class="org.jboss.tools.common.validation.CommonValidationPlugin">
+	   </startup>
+   </extension>
+    
    <extension
         point="org.eclipse.wst.validation.validator"
 		id="cd"


### PR DESCRIPTION
The AYT Validator Start Up initialization is fixed

Signed-off-by: vrubezhny vrubezhny@exadel.com
