### PR TITLE
JBDS-3066 : ensure ide-config.properties loads from org.jboss.tools.foundation.core when offline

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/VersionPropertiesProvider.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/VersionPropertiesProvider.java
@@ -114,7 +114,7 @@ public class VersionPropertiesProvider implements IPropertiesProvider, IExecutab
     return id;
   }
 
-  private void initPropertiesUri(String propertiesURI) {
+  protected void initPropertiesUri(String propertiesURI) {
     try {
       if (propertiesURI == null) {
         this.propertiesURI = new URI(System.getProperty(VERSION_PROPERTIES_URI_KEY, DEFAULT_PROPERTIES_URI));
@@ -180,9 +180,9 @@ public class VersionPropertiesProvider implements IPropertiesProvider, IExecutab
     return output.toString();
   }
 
-  private Properties loadDefaultProperties() {
+  protected Properties loadDefaultProperties() {
     try {
-      return getProperties(getClass().getResourceAsStream(
+      return getProperties(VersionPropertiesProvider.class.getResourceAsStream(
           DEFAULT_PROPERTIES_FILE));
     } catch (Exception e) {
       // Shouldn't happen unless Maven wasn't called to download the remote

--- a/foundation/tests/org.jboss.tools.foundation.core.test/fragment.xml
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/fragment.xml
@@ -6,7 +6,7 @@
          <propertiesProvider
             id="dummy.properties.provider"
             context="jbosstools"
-            class="org.jboss.tools.foundation.core.properties.internal.MockVersionProvider"
+            class="org.jboss.tools.foundation.core.properties.mock.MockVersionProvider"
             priority="-9999">
          </propertiesProvider>
    </extension>

--- a/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/properties/internal/PropertiesProviderFactoryTest.java
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/properties/internal/PropertiesProviderFactoryTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 
 import org.jboss.tools.foundation.core.properties.IPropertiesProvider;
+import org.jboss.tools.foundation.core.properties.mock.MockVersionProvider;
 import org.junit.Test;
 
 public class PropertiesProviderFactoryTest {

--- a/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/properties/internal/VersionProviderTest.java
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/properties/internal/VersionProviderTest.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.jboss.tools.foundation.core.properties.IPropertiesProvider;
 import org.jboss.tools.foundation.core.properties.PropertiesHelper;
+import org.jboss.tools.foundation.core.properties.mock.MockDevStudioPropertiesProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -192,8 +193,7 @@ public class VersionProviderTest {
 
   @Test
   public void testFallBackEmbeddedValues() throws Exception {
-    VersionPropertiesProvider provider = new VersionPropertiesProvider(
-        "file://crap.url", "devstudio", "8.0.0");
+    VersionPropertiesProvider provider = new MockDevStudioPropertiesProvider();
     assertNotNull(provider.getValue("jboss.discovery.site.url"));
   }
 

--- a/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/properties/mock/MockDevStudioPropertiesProvider.java
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/properties/mock/MockDevStudioPropertiesProvider.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.core.properties.mock;
+
+import org.jboss.tools.foundation.core.properties.internal.VersionPropertiesProvider;
+
+/**
+ * Properties Provider for mocking JBoss Developer Studio
+ *
+ * @author Fred Bricon
+ */
+public class MockDevStudioPropertiesProvider extends VersionPropertiesProvider {
+
+  public MockDevStudioPropertiesProvider() {
+    super();
+    initPropertiesUri("file://crap.url");
+  }
+
+  protected String getCurrentVersion() {
+	  return "8.0.0";
+  };
+  
+  @Override
+  protected String getContext() {
+	return "devstudio";
+  }
+}

--- a/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/properties/mock/MockVersionProvider.java
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/properties/mock/MockVersionProvider.java
@@ -1,4 +1,4 @@
-package org.jboss.tools.foundation.core.properties.internal;
+package org.jboss.tools.foundation.core.properties.mock;
 
 import org.jboss.tools.foundation.core.properties.IPropertiesProvider;
 


### PR DESCRIPTION
The heart of the fix is https://github.com/fbricon/jbosstools-base/compare/jbosstools:jbosstools-4.2.0.Beta2x...JBDS-3066-4.2.0.Beta2x?expand=1#diff-590f1aab49f4c8100293e01ed2c64a6aR185

The rest of the changes is for unit testing 
