### PR TITLE
JBIDE-17888 Make mobile palette available for angularJS template files

### DIFF
--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/views/palette/PaletteContents.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/views/palette/PaletteContents.java
@@ -62,7 +62,10 @@ public class PaletteContents {
 			if (input instanceof IFileEditorInput) {
 				IFile file = ((IFileEditorInput)input).getFile();
 				if(file != null) {
-					if(FileUtil.isDoctypeHTML(file)) {
+					String doctype = FileUtil.getDoctype(FileUtil.getContentFromEditorOrFile(file));
+					if("html".equalsIgnoreCase(doctype) 
+						|| (doctype == null && file.getName().endsWith(".html"))
+							) {
 						result = new String[]{TYPE_MOBILE}; //$NON-NLS-1$
 					} else {
 						result = new String[]{TYPE_JSF}; //$NON-NLS-1$

--- a/common/plugins/org.jboss.tools.common/src/org/jboss/tools/common/util/FileUtil.java
+++ b/common/plugins/org.jboss.tools.common/src/org/jboss/tools/common/util/FileUtil.java
@@ -74,6 +74,10 @@ public final class FileUtil extends FileUtils {
 	}
 
 	public static boolean isDoctypeHTML(String content) {
+		return "html".equalsIgnoreCase(getDoctype(content));
+	}
+
+	public static String getDoctype(String content) {
 		int i = 0;
 		while(true) {
 			i = content.indexOf("<!", i);
@@ -88,15 +92,15 @@ public final class FileUtil extends FileUtils {
 			} else if(content.indexOf("<!", i + 1) > i && content.indexOf("<!", i + 1) < j) {
 				i += 2;
 				continue;
-			} else if(j > i + 13) {
+			} else if(j > i + 10) {
 				String dt1 = content.substring(i + 2, i + 9).trim();
 				if("doctype".equalsIgnoreCase(dt1)) {
 					String dt = content.substring(i + 9, j).trim();
-					return dt.equalsIgnoreCase("html");
+					return dt;
 				}
 			}
 			break;
 		}
-		return false;
+		return null;
 	}
 }


### PR DESCRIPTION
Open mobile palette when file
1) has <!doctype html>
2) has extension *.html and does not have doctype declaration.
