### PR TITLE
JBIDE-17849 CSS Hyperlinks aren't working on non-WTP projects

### DIFF
--- a/common/plugins/org.jboss.tools.common.core/src/org/jboss/tools/common/core/Messages.java
+++ b/common/plugins/org.jboss.tools.common.core/src/org/jboss/tools/common/core/Messages.java
@@ -31,6 +31,9 @@ public class Messages extends NLS {
 	public static String ECFExamplesTransport_Server_redirected_too_many_times;
 	public static String ECFTransport_Operation_canceled;
 	
+	public static String WebUtil_NullArgument;
+	
+	
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/common/plugins/org.jboss.tools.common.core/src/org/jboss/tools/common/core/messages.properties
+++ b/common/plugins/org.jboss.tools.common.core/src/org/jboss/tools/common/core/messages.properties
@@ -18,3 +18,5 @@ ECFExamplesTransport_Loading=Loading
 ECFExamplesTransport_ReceivedSize_Of_FileSize_At_RatePerSecond={0} of {1} (at {2}/s) 
 ECFExamplesTransport_Server_redirected_too_many_times=Server redirected too many times
 ECFTransport_Operation_canceled=Operation canceled
+
+WebUtil_NullArgument=Argument '{0}' cannot be null!

--- a/common/tests/org.jboss.tools.common.core.test/projects/DynamicWebProject/WebContent/css/some.css
+++ b/common/tests/org.jboss.tools.common.core.test/projects/DynamicWebProject/WebContent/css/some.css
@@ -1,0 +1,5 @@
+/* test css stylesheet */
+
+body {
+  padding-top: 20px;
+}

--- a/common/tests/org.jboss.tools.common.core.test/projects/DynamicWebProject/WebContent/pages/index.html
+++ b/common/tests/org.jboss.tools.common.core.test/projects/DynamicWebProject/WebContent/pages/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Test Context Resource</title>
+  <link rel="stylesheet" href="/css/some.css">
+</head>
+<body>
+
+      <!--Body content-->
+
+</body>
+</html>

--- a/common/tests/org.jboss.tools.common.core.test/projects/DynamicWebProject/WebContentDefault/pages/indexF1.html
+++ b/common/tests/org.jboss.tools.common.core.test/projects/DynamicWebProject/WebContentDefault/pages/indexF1.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Test Context Resource</title>
+  <link rel="stylesheet" href="/css/some.css">
+</head>
+<body>
+
+      <!--Body content-->
+
+</body>
+</html>

--- a/common/tests/org.jboss.tools.common.core.test/projects/ProjectResource/WebContent/css/some.css
+++ b/common/tests/org.jboss.tools.common.core.test/projects/ProjectResource/WebContent/css/some.css
@@ -1,0 +1,5 @@
+/* test css stylesheet */
+
+body {
+  padding-top: 20px;
+}

--- a/common/tests/org.jboss.tools.common.core.test/projects/ProjectResource/WebContent/pages/index.html
+++ b/common/tests/org.jboss.tools.common.core.test/projects/ProjectResource/WebContent/pages/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Test Context Resource</title>
+  <link rel="stylesheet" href="/css/some.css">
+</head>
+<body>
+
+      <!--Body content-->
+
+</body>
+</html>

--- a/common/tests/org.jboss.tools.common.core.test/projects/SimpleDynamicWebProject/WebContent/css/some.css
+++ b/common/tests/org.jboss.tools.common.core.test/projects/SimpleDynamicWebProject/WebContent/css/some.css
@@ -1,0 +1,5 @@
+/* test css stylesheet */
+
+body {
+  padding-top: 20px;
+}

--- a/common/tests/org.jboss.tools.common.core.test/projects/SimpleDynamicWebProject/WebContent/pages/index.html
+++ b/common/tests/org.jboss.tools.common.core.test/projects/SimpleDynamicWebProject/WebContent/pages/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Test Context Resource</title>
+  <link rel="stylesheet" href="/css/some.css">
+</head>
+<body>
+
+      <!--Body content-->
+
+</body>
+</html>

--- a/common/tests/org.jboss.tools.common.core.test/src/org/jboss/tools/common/core/test/WebUtilsTest.java
+++ b/common/tests/org.jboss.tools.common.core.test/src/org/jboss/tools/common/core/test/WebUtilsTest.java
@@ -16,11 +16,14 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.File;
+
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 import org.jboss.tools.common.web.WebUtils;
 import org.jboss.tools.test.util.ResourcesUtils;
 import org.junit.Before;
@@ -150,6 +153,78 @@ public class WebUtilsTest {
 		assertNull(path);
 	}
 
+	@Test
+	public void testFindResource() {
+		
+		// Dynamic Web Project
+		IFile context1 = dynamicWebProject.getFile("WebContent/pages/index.html");
+		IFile context2 = dynamicWebProject.getFile("WebContentDefault/pages/indexF1.html");
+		assertTrue("Context file not found", context1.exists() && context1.isAccessible());
+		assertTrue("Context file not found", context2.exists() && context2.isAccessible());
+
+		File testFile = dynamicWebProject.getFile("WebContent/css/some.css").getLocation().toFile(); 
+		assertTrue("Context file not found", testFile.exists() && testFile.canRead());
+				
+		// Relative path
+		IResource resource = WebUtils.findResource(context1, "../css/some.css");
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		resource = WebUtils.findResource(context2, "../css/some.css");
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		// Absolute path in project
+		resource = WebUtils.findResource(context1, "/css/some.css");
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		resource = WebUtils.findResource(context2, "/css/some.css");
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		// Absolute location path
+		IPath location = dynamicWebProject.getLocation()
+				.append("WebContent")
+				.append(new Path("css/some.css"));
+		resource = WebUtils.findResource(context1, location.toString());
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		resource = WebUtils.findResource(context2, location.toString());
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		
+		// Simple Web Project
+		IFile context = simpleDynamicWebProject.getFile("WebContent/pages/index.html");
+		assertTrue("Context file not found", context.exists() && context.isAccessible());
+
+		testFile = simpleDynamicWebProject.getFile("WebContent/css/some.css").getLocation().toFile(); 
+		assertTrue("Context file not found", testFile.exists() && testFile.canRead());
+
+		// Relative path
+		resource = WebUtils.findResource(context, "../css/some.css");
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		// Absolute path in project
+		resource = WebUtils.findResource(context, "/css/some.css");
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		// Absolute location path
+		location = simpleDynamicWebProject.getLocation()
+				.append("WebContent")
+				.append(new Path("css/some.css"));
+		resource = WebUtils.findResource(context, location.toString());
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		
+		// Resource Web Project
+		context = resourceProject.getFile("WebContent/pages/index.html");
+		assertTrue("Context file not found", context.exists() && context.isAccessible());
+		
+		testFile = resourceProject.getFile("WebContent/css/some.css").getLocation().toFile(); 
+		assertTrue("Context file not found", testFile.exists() && testFile.canRead());
+		
+		// Relative path
+		resource = WebUtils.findResource(context, "../css/some.css");
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		// Absolute path in project
+		resource = WebUtils.findResource(context, "/css/some.css");
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+		// Absolute location path
+		location = resourceProject.getLocation()
+				.append("WebContent")
+				.append(new Path("css/some.css"));
+		resource = WebUtils.findResource(context, location.toString());
+		assertTrue(resource != null && resource.getLocation().toFile().equals(testFile));
+	}
+	
 	private void assertArrayContainsMemeber(Object[] array, Object member) {
 		StringBuilder sb = new StringBuilder("[");
 		for (int i = 0; i < array.length; i++) {


### PR DESCRIPTION
An utility helper method is added due to find pages in projects that are not the WTP ones
(has no web-roots that can be achieved by WTP methods)

Signed-off-by: vrubezhny vrubezhny@exadel.com
