### PR TITLE
JBIDE-17866 JSF/KB memory leak

### DIFF
--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/meta/impl/XAttributeImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/meta/impl/XAttributeImpl.java
@@ -249,7 +249,7 @@ class AdapterHolder {
         }
 		
 		loader = null;
-		element = null;
+		this.element = null;
 		this.adapter = adapter;
 	}
 

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/FileSystemsImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/FileSystemsImpl.java
@@ -223,6 +223,15 @@ public class FileSystemsImpl extends OrderedObjectImpl implements IResourceChang
     }
 
 	public void resourceChanged(IResourceChangeEvent event) {
+		if(event.getType() == IResourceChangeEvent.PRE_DELETE
+				&& event.getResource() instanceof IProject && event.getResource().equals(EclipseResourceUtil.getProject(this))) {
+			ModelPlugin.getWorkspace().removeResourceChangeListener(this);
+			ModelPlugin.getDefault().getSaveParticipant().removeModel(getModel());
+			libs.destroy();
+//TODO implement safe destroy.
+//			destroy();
+			return;
+		}
 		if(!isActive() || event == null || event.getDelta() == null) return;
 		if(!checkDelta(event.getDelta())) return;
 		List<IResourceDelta> fileDeltas = findFileDeltas(event.getDelta(), null);

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/FolderImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/FolderImpl.java
@@ -147,7 +147,7 @@ public class FolderImpl extends RegularObjectImpl implements FolderLoader {
     protected String getAbsolutePath() {
     	FolderImpl parent = (FolderImpl)getParent();
         String p = (parent == null) ? null : parent.getAbsolutePath();
-        if(parent.linked.containsFile(getPathPart())) {
+        if(parent != null && parent.linked.containsFile(getPathPart())) {
         	return parent.linked.getFileByFileName(getPathPart()).getAbsolutePath();
         }
         return (p == null) ? null : p + XModelObjectConstants.SEPARATOR + name();
@@ -200,7 +200,9 @@ public class FolderImpl extends RegularObjectImpl implements FolderLoader {
         }
     }
 	private void loadChildren(File[] fs, IResource[] rs) {
-		FileSystemPeer peer = getFileSystem().getPeer();
+    	FileSystemImpl fileSystem = getFileSystem();
+    	if(fileSystem == null) return;
+		FileSystemPeer peer = fileSystem.getPeer();
         for (int i = 0; i < fs.length; i++) {
         	_loadChild(peer, fs[i]);
         }
@@ -340,7 +342,7 @@ public class FolderImpl extends RegularObjectImpl implements FolderLoader {
         updateLock++;
         Map<String,File> mf = new HashMap<String,File>();
         linked.clearFiles();
-        XModelObject fileSystem = getFileSystem();
+        FileSystemImpl fileSystem = getFileSystem();
         if(fileSystem == null) return false;
 		FileSystemsImpl fsi = (FileSystemsImpl)fileSystem.getParent();
       try {  
@@ -406,9 +408,9 @@ public class FolderImpl extends RegularObjectImpl implements FolderLoader {
             XModelObject o = (XModelObject)mc.get(nm);
             File of = getChildIOFile(o);
             if(o.getFileType() == XModelObject.FOLDER) {
-                if(!getFileSystem().getPeer().containsDir(of)) continue;
+                if(!fileSystem.getPeer().containsDir(of)) continue;
             } else {
-                if(!getFileSystem().getPeer().contains(of)) continue;
+                if(!fileSystem.getPeer().contains(of)) continue;
             }
             toRemove.put(nm, o);
             io.remove();
@@ -591,7 +593,9 @@ public class FolderImpl extends RegularObjectImpl implements FolderLoader {
     }
 
     protected void updateLoaded(XModelObject o, File f) throws XModelException {
-        FileSystemPeer peer = getFileSystem().getPeer();
+    	FileSystemImpl fs = getFileSystem();
+    	if(fs == null) return;
+        FileSystemPeer peer = fs.getPeer();
         if(o instanceof FolderImpl) {
         	if(!o.getAttributeValue(XModelObjectConstants.ATTR_NAME).equals(f.getName())) {
         		o.setAttributeValue(XModelObjectConstants.ATTR_NAME, f.getName());
@@ -660,7 +664,9 @@ public class FolderImpl extends RegularObjectImpl implements FolderLoader {
     }
     
     public void updateChildFile(XModelObject o, File f) throws XModelException {
-		FileSystemPeer peer = getFileSystem().getPeer();
+    	FileSystemImpl fs = getFileSystem();
+    	if(fs == null) return;
+		FileSystemPeer peer = fs.getPeer();
 		if(f.isFile() && peer.contains(f) && !peer.isUpdated(f)) return;
 		int i = (!o.isModified()) ? 0 :	question(f);
 		if(i < 0) return;
@@ -711,7 +717,9 @@ public class FolderImpl extends RegularObjectImpl implements FolderLoader {
     }
 
     protected boolean updateNew(String pathpart, File f, Map<String,XModelObject> toRemove) throws XModelException {
-        FileSystemPeer peer = getFileSystem().getPeer();
+    	FileSystemImpl fs = getFileSystem();
+    	if(fs == null) return false;
+        FileSystemPeer peer = fs.getPeer();
         if(peer.contains(f) && !peer.isUpdated(f)) return false;
         XModelObject c = null;
         if(f.isDirectory()) {
@@ -759,7 +767,9 @@ public class FolderImpl extends RegularObjectImpl implements FolderLoader {
 
     protected void updateRemove(XModelObject o) throws XModelException {
         boolean d = (o instanceof FolderImpl);
-        final FileSystemPeer peer = getFileSystem().getPeer();
+    	FileSystemImpl fs = getFileSystem();
+    	if(fs == null) return;
+        final FileSystemPeer peer = fs.getPeer();
         final File rf = getChildIOFile(o);
         boolean c = (d && peer.containsDir(rf)) || ((!d) && peer.contains(rf));
         if(!c) return;
@@ -792,8 +802,10 @@ public class FolderImpl extends RegularObjectImpl implements FolderLoader {
     }
     
     public void removeChildFile(XModelObject o) {
+    	FileSystemImpl fs = getFileSystem();
+    	if(fs == null) return;
 		boolean d = (o instanceof FolderImpl);
-		FileSystemPeer peer = getFileSystem().getPeer();
+		FileSystemPeer peer = fs.getPeer();
 		File rf = getChildIOFile(o);
 		boolean c = (d && peer.containsDir(rf)) || ((!d) && peer.contains(rf));
 		if(!c) return;

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/Libs.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/Libs.java
@@ -63,6 +63,10 @@ public class Libs implements IElementChangedListener {
 		JavaCore.addElementChangedListener(this);
 	}
 
+	public void destroy() {
+		JavaCore.removeElementChangedListener(this);
+	}
+
 	private IProject getProjectResource() {
 		return EclipseResourceUtil.getProject(object);
 	}

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/impl/RegularObjectImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/impl/RegularObjectImpl.java
@@ -30,6 +30,18 @@ public class RegularObjectImpl extends XModelObjectImpl implements XOrderedObjec
         return new RegularChildren();
     }
 
+    public void destroy() {
+    	if(children != null && !children.isEmpty()) {
+    		XModelObject[] h = children.getObjects();
+    		for (XModelObject o: h) {
+    			((XModelObjectImpl)o).destroy();
+    		}
+    		//TODO provide safe work at setting children to null.
+    		children = createChildren();
+    	}
+    	super.destroy();
+    }
+
     public boolean areChildrenOrdered() {
     	return children != null && children.areChildrenOrdered();
     }

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/impl/XModelObjectImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/impl/XModelObjectImpl.java
@@ -65,7 +65,18 @@ public class XModelObjectImpl implements XModelObject, Serializable, Cloneable {
     public XModelEntity getModelEntity() {
         return entity;
     }
-    
+
+    /**
+     * Destroys object.
+     */
+    public void destroy() {
+//TODO provide safe work at removing model, entity etc.
+//    	model = null;
+    	parent = null;
+//    	entity = null;
+    	//
+    }
+
     public void changeEntity(String name) {
     	if(entity.getName().equals(name)) return;
     	XModelEntity newEntity = entity.getMetaModel().getEntity(name);

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/util/EclipseResourceUtil.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/util/EclipseResourceUtil.java
@@ -70,6 +70,7 @@ import org.jboss.tools.common.model.project.IModelNature;
 import org.jboss.tools.common.model.project.ModelNature;
 import org.jboss.tools.common.model.project.ModelNatureExtension;
 import org.jboss.tools.common.util.FileUtils;
+import org.jboss.tools.common.util.UniquePaths;
 import org.jboss.tools.common.web.WebUtils;
 import org.osgi.framework.Bundle;
 
@@ -1133,7 +1134,10 @@ public class EclipseResourceUtil extends EclipseUtil {
 			if(event.getType() == IResourceChangeEvent.PRE_DELETE) {
 				IResource resource = event.getResource();
 				IProject project = (IProject)resource.getAdapter(IProject.class);
-				if(project != null) models.remove(project);
+				if(project != null) {
+					models.remove(project);
+					UniquePaths.getInstance().clean(project);
+				}
 			}
 		}
 		


### PR DESCRIPTION
UniquePaths cleaned at project deletion.
Resource and Java model listeners are removed at project deletion.
