### PR TITLE
JBIDE-19249 ResourceException: Missing project nature extension for org....

### DIFF
--- a/common/plugins/org.jboss.tools.common.core/src/org/jboss/tools/common/web/WebUtils.java
+++ b/common/plugins/org.jboss.tools.common.core/src/org/jboss/tools/common/web/WebUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2014 Red Hat, Inc.
+ * Copyright (c) 2011 - 2015 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -156,11 +156,7 @@ public class WebUtils {
 		if(www !=null && www.getType() == IResource.FOLDER) {
 			webroot = (IFolder)www;
 			try {
-				IProjectNature nature = project.getNature(THYM_NATURE_ID);
-				if(nature==null) {
-					nature = project.getNature(AEROGEAR_NATURE_ID);
-				}
-				if(nature==null) {
+				if(project.hasNature(THYM_NATURE_ID) || project.hasNature(AEROGEAR_NATURE_ID)) {
 					IResource configXml = project.findMember(CONFIG_XML);
 					if(configXml ==null || configXml.getType() != IResource.FILE) {
 						configXml = webroot.findMember(CONFIG_XML);


### PR DESCRIPTION
...eclipse.thym.core.HybridAppNature

Unneeded IProject's getNature() calls were replaced by the calls to hasNature() with doesn't create the nature extension.

Signed-off-by: vrubezhny <vrubezhny@exadel.com>