### PR TITLE
JBIDE-19713 Location of 'runtime-locations.proprty'

### DIFF
--- a/runtime/plugins/org.jboss.tools.runtime.ui/src/org/jboss/tools/runtime/ui/internal/startup/JBossRuntimeStartup.java
+++ b/runtime/plugins/org.jboss.tools.runtime.ui/src/org/jboss/tools/runtime/ui/internal/startup/JBossRuntimeStartup.java
@@ -37,8 +37,8 @@ public class JBossRuntimeStartup {
 	private static final String USER_HOME = "user.home"; //$NON-NLS-1$
 	private static final String JBOSS_EAP_HOME = "../../runtimes/jboss-eap"; 	// JBoss EAP home directory (relative to plugin)- <RHDS_HOME>/jbossas. //$NON-NLS-1$
 	private static final String LOCATIONS_FILE_NAME = "runtime_locations.properties"; //$NON-NLS-1$
-	private static final String LOCATIONS_FILE = "../../../../studio/" + LOCATIONS_FILE_NAME; //$NON-NLS-1$
-	private static final String LOCATIONS_FILE_CONFIGURATION = "../../studio/" + LOCATIONS_FILE_NAME; //$NON-NLS-1$
+	private static final String LOCATIONS_FILE = "../../../" + LOCATIONS_FILE_NAME; //$NON-NLS-1$
+	private static final String LOCATIONS_FILE_CONFIGURATION = "../" + LOCATIONS_FILE_NAME; //$NON-NLS-1$
 	
 	public static void initializeRuntimes(IProgressMonitor monitor) {
 		initializeEAPRuntimes(monitor);


### PR DESCRIPTION
Fix removes not required part for relative path "../studio"