### PR TITLE
JBIDE-19847 : use short sha1-based file names instead of long sanitized url names

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/ecf/internal/URLTransportCache.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/ecf/internal/URLTransportCache.java
@@ -36,6 +36,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.jboss.tools.foundation.core.FoundationCorePlugin;
 import org.jboss.tools.foundation.core.Trace;
+import org.jboss.tools.foundation.core.digest.DigestUtils;
 import org.jboss.tools.foundation.core.ecf.Messages;
 import org.jboss.tools.foundation.core.ecf.URLTransportUtility;
 
@@ -305,8 +306,13 @@ public class URLTransportCache {
 		// Otherwise, make a new one
 		File root = getLocalCacheFolder().toFile();
 		root.mkdirs();
-		
-		String tmp = url.replaceAll("[\\p{Punct}&&[^_]]", "_");
+		String tmp;
+		try {
+			tmp = DigestUtils.sha1(url);
+		} catch (IOException O_o) {
+		  //That really can't happen
+			tmp = url.replaceAll("[\\p{Punct}&&[^_]]", "_");
+		}
 		
 		File cached = null;
 		do {

--- a/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/test/ecf/URLTransportUtilTest.java
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/src/org/jboss/tools/foundation/core/test/ecf/URLTransportUtilTest.java
@@ -73,6 +73,13 @@ public class URLTransportUtilTest extends TestCase {
 		testLastModified(urlString);
 	}
 	
+	public void testLongUrl() throws CoreException {
+	  String urlString = "http://thelongestlistofthelongeststuffatthelongestdomainnameatlonglast.com/wearejustdoingthistobestupidnowsincethiscangoonforeverandeverandeverbutitstilllookskindaneatinthebrowsereventhoughitsabigwasteoftimeandenergyandhasnorealpointbutwehadtodoitanyways.html";
+	  File file = new URLTransportUtility().getCachedFileForURL(urlString, "Long Url", URLTransportUtility.CACHE_UNTIL_EXIT, new NullProgressMonitor());
+	  assertTrue(file.exists());
+	  assertTrue(file.length() > 0);
+	}
+	
 	
 	protected FakeHttpServer startFakeSlowHttpServer(String statusLine) throws IOException {
 		return startFakeHttpServer(statusLine, 45000);


### PR DESCRIPTION


Signed-off-by: Fred Bricon <fbricon@gmail.com>