### PR TITLE
JBDS-3490 Include capabilities preference page into jbdevstudio product

### DIFF
--- a/common/plugins/org.jboss.tools.common.model.ui.capabilities/plugin.properties
+++ b/common/plugins/org.jboss.tools.common.model.ui.capabilities/plugin.properties
@@ -1,6 +1,6 @@
 providerName=JBoss by Red Hat
 pluginName=JBoss Tools Experimental JSF/Struts Project Templates Development
 
-CategoryName_experimental=JBoss Tools Experimental configuration
+CategoryName_experimental=JBoss Tools Experimental
 CategoryDescription_experimental=It allows create Custom Capabilities, Library sets and Project templates for JSF/Struts projects
 ActivityName_templates=JSF/Struts Project Templates Development


### PR DESCRIPTION
Rename capabilities category to "JBoss Tools Experimental" to have
better look in Capabilities dialog compare to "JBoss Tools Experimental
configuration" wich doesn't fit into control.