### PR TITLE
JBIDE-20580 Performance: EL resolvers unnecessarily create a lot of empty ArrayList instances

### DIFF
--- a/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/ca/AbstractELCompletionEngine.java
+++ b/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/ca/AbstractELCompletionEngine.java
@@ -133,14 +133,7 @@ public abstract class AbstractELCompletionEngine<V extends IVariable> implements
 	public List<TextProposal> getProposals(ELContext context, String el, int offset) {
 		List<TextProposal> completions = new ArrayList<TextProposal>();
 
-		List<Var> vars = EMPTY_VARS;
-		Var[] array = context.getVars(offset);
-		if(array.length > 0) {
-			vars = new ArrayList<Var>();
-		}
-		for (int i = 0; i < array.length; i++) {
-			vars.add(array[i]);
-		}
+		List<Var> vars = context.getVarsAsList(offset);
 
 		ELResolutionImpl resolution;
 		try {
@@ -166,14 +159,7 @@ public abstract class AbstractELCompletionEngine<V extends IVariable> implements
 	 * @see org.jboss.tools.common.el.core.resolver.ELResolver#resolve(org.jboss.tools.common.el.core.resolver.ELContext, org.jboss.tools.common.el.core.model.ELExpression)
 	 */
 	public ELResolution resolve(ELContext context, ELExpression operand, int offset) {
-		List<Var> vars = EMPTY_VARS;
-		Var[] array = context.getVars(offset);
-		if(array.length > 0) {
-			vars = new ArrayList<Var>();
-		}
-		for (int i = 0; i < array.length; i++) {
-			vars.add(array[i]);
-		}
+		List<Var> vars = context.getVarsAsList(offset);
 		ELResolutionImpl resolution = null;
 		try {
 			resolution = resolveELOperand(context.getResource(), context, operand, true, vars, new ElVarSearcher(context.getResource(), this), offset);
@@ -196,14 +182,7 @@ public abstract class AbstractELCompletionEngine<V extends IVariable> implements
 	 * @return
 	 */
 	public ELResolution resolveELOperand(ELExpression operand, ELContext context, boolean returnEqualedVariablesOnly, int offset) {
-		List<Var> vars = EMPTY_VARS;
-		Var[] array = context.getVars(offset);
-		if(array.length > 0) {
-			vars = new ArrayList<Var>();
-			for (int i = 0; i < array.length; i++) {
-				vars.add(array[i]);
-			}
-		}
+		List<Var> vars = context.getVarsAsList(offset);
 		try {
 			return resolveELOperand(context.getResource(), context, operand, returnEqualedVariablesOnly, vars, new ElVarSearcher(context.getResource(), this), offset);
 		} catch (StringIndexOutOfBoundsException e) {

--- a/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/ELContext.java
+++ b/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/ELContext.java
@@ -37,6 +37,14 @@ public interface ELContext {
 	Var[] getVars(int offset);
 
 	/**
+	 * Returns "var" attributes which are available in particular offset or the all "var"s if offset == -1 
+	 * 
+	 * @param offset
+	 * @return
+	 */
+	List<Var> getVarsAsList(int offset);
+
+	/**
 	 * Returns all EL references of the file of this context.
 	 * 
 	 * @return

--- a/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/ELContextImpl.java
+++ b/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/ELContextImpl.java
@@ -26,7 +26,7 @@ import org.jboss.tools.common.el.core.ELReference;
  * @author Alexey Kazakov
  */
 public class ELContextImpl extends SimpleELContext {
-	static List<Var> EMPTY = Collections.<Var>emptyList();
+	public static final List<Var> EMPTY = Collections.<Var>emptyList();
 
 	protected List<Var> allVars = new ArrayList<Var>();
 	protected ELReference[] elReferences;
@@ -38,16 +38,22 @@ public class ELContextImpl extends SimpleELContext {
 	 */
 	@Override
 	public synchronized Var[] getVars() {
+		List<Var> vars = getVarsAsList();
+		return vars.toArray(new Var[vars.size()]);
+	}
+
+	@Override
+	public synchronized List<Var> getVarsAsList() {
 		List<Var> external = getExternalVars();
 		if(external.isEmpty()) {
-			return allVars.toArray(new Var[allVars.size()]);
+			return allVars;
 		} else if(allVars.isEmpty()) {
-			return external.toArray(new Var[allVars.size()]);
+			return external;
 		}
 		ArrayList<Var> result = new ArrayList<Var>();
 		result.addAll(allVars);
 		result.addAll(external);
-		return result.toArray(new Var[allVars.size()]);
+		return result;
 	}
 
 	/**
@@ -76,8 +82,18 @@ public class ELContextImpl extends SimpleELContext {
 	 */
 	@Override
 	public synchronized Var[] getVars(int offset) {
-		if(offset<0) {
-			return getVars();
+		List<Var> vars = getVarsAsList(offset);
+		return vars.toArray(new Var[vars.size()]);
+	}
+
+	@Override
+	public synchronized List<Var> getVarsAsList(int offset) {
+		if(offset < 0) {
+			return getVarsAsList();
+		}
+		List<Var> external = getExternalVars();
+		if(allVars.isEmpty()) {
+			return external;
 		}
 		List<Var> result = new ArrayList<Var>();
 		for (Var var : allVars) {
@@ -86,11 +102,10 @@ public class ELContextImpl extends SimpleELContext {
 				result.add(var);
 			}
 		}
-		List<Var> external = getExternalVars();
 		if(!external.isEmpty()) {
 			result.addAll(external);
 		}
-		return result.toArray(new Var[result.size()]);
+		return result;
 	}
 
 	/**

--- a/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/SimpleELContext.java
+++ b/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/resolver/SimpleELContext.java
@@ -67,7 +67,12 @@ public class SimpleELContext implements ELContext {
 	 * @see org.jboss.tools.common.el.core.resolver.ELContext#getVars()
 	 */
 	public Var[] getVars() {
+		List<Var> vars = getVarsAsList();
 		return vars.toArray(new Var[vars.size()]);
+	}
+
+	public List<Var> getVarsAsList() {
+		return vars;
 	}
 
 	/*
@@ -100,6 +105,10 @@ public class SimpleELContext implements ELContext {
 	 */
 	public Var[] getVars(int offset) {
 		return getVars();
+	}
+
+	public List<Var> getVarsAsList(int offset) {
+		return getVarsAsList();
 	}
 
 	/*


### PR DESCRIPTION
ELContext.getVarsAsList(int) method is added to prevent creating
auxiliary lists transformed into arrays and then put into lists again.