### PR TITLE
JBIDE-20217 - rogue npe, adds a check but does not resolve root cause

### DIFF
--- a/common/plugins/org.jboss.tools.common.jdt.debug/src/org/jboss/tools/common/jdt/debug/RemoteDebugActivator.java
+++ b/common/plugins/org.jboss.tools.common.jdt.debug/src/org/jboss/tools/common/jdt/debug/RemoteDebugActivator.java
@@ -195,7 +195,7 @@ public class RemoteDebugActivator extends BaseCorePlugin implements IPropertyCha
 	}
 	
 	public boolean isDebugModel(VmModel model) {
-		if (model.getPort() != null && DT_SOCKET.equals(model.getTransport())) {
+		if (model != null && model.getDebugPort() != null && DT_SOCKET.equals(model.getTransport())) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
This patch ensures an NPE doesn't blow away the stack, but it does not solve the root cause of why there's an NPE. It's possible that the root cause is related to JBIDE-20510,  but for now, this NPE check will ensure that isDebugModel(etc) returns correctly in the event of a not-found vm model (ie, a vm model that's not found is not debugable). 