### PR TITLE
Improve operations that require SSE model

### DIFF
--- a/common/plugins/org.jboss.tools.common.text.ext/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.text.ext/META-INF/MANIFEST.MF
@@ -30,5 +30,5 @@ Require-Bundle: org.jboss.tools.common.model,
  org.eclipse.wst.css.core;bundle-version="1.1.500",
  org.eclipse.wst.html.core;bundle-version="1.1.500",
  org.jboss.tools.common.ui
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .

--- a/common/plugins/org.jboss.tools.common.text.ext/src/org/jboss/tools/common/text/ext/util/StructuredModelWrapper.java
+++ b/common/plugins/org.jboss.tools.common.text.ext/src/org/jboss/tools/common/text/ext/util/StructuredModelWrapper.java
@@ -7,34 +7,33 @@
  *
  * Contributors:
  *     Exadel, Inc. and Red Hat, Inc. - initial API and implementation
- ******************************************************************************/ 
+ ******************************************************************************/
 package org.jboss.tools.common.text.ext.util;
 
 import java.io.IOException;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.util.SafeRunnable;
 import org.eclipse.wst.sse.core.StructuredModelManager;
 import org.eclipse.wst.sse.core.internal.provisional.IModelManager;
 import org.eclipse.wst.sse.core.internal.provisional.IStructuredModel;
-import org.eclipse.wst.sse.core.internal.provisional.text.IStructuredDocument;
 import org.eclipse.wst.xml.core.internal.provisional.document.IDOMDocument;
 import org.eclipse.wst.xml.core.internal.provisional.document.IDOMModel;
 import org.jboss.tools.common.model.XModel;
 import org.jboss.tools.common.text.ext.ExtensionsPlugin;
 import org.jboss.tools.common.text.ext.hyperlink.AbstractHyperlink;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
+@SuppressWarnings("restriction")
 public class StructuredModelWrapper {
 	/**
-	 * Interface to use with static <code>execute(IFile file, final Command command)</code>
-	 * method. Use inner class if access to class' fields or final local variables 
-	 * is required.
+	 * Interface to use with static
+	 * <code>execute(IFile file, final Command command)</code> method. Use inner
+	 * class if access to class' fields or final local variables is required.
 	 * 
-	 * @see StructuredModelWrapper.execute(IFile file, final Command command)  
+	 * @see StructuredModelWrapper.execute(IFile file, final Command command)
 	 */
 	public interface ICommand {
 		/**
@@ -43,14 +42,24 @@ public class StructuredModelWrapper {
 		 *        method. It is never called with null value.
 		 */
 		void execute(IDOMDocument xmlDocument);
-		
+
+	}
+
+	public interface ICommand2<T> {
+		/**
+		 * Execute code related to <code>xmlDocument instance<code>.
+		 * @param xmlDocument - document for file passed to <code>StructuredModelWrapper.execute</code>
+		 *        method. It is never called with null value.
+		 */
+		T execute(IStructuredModel sModel);
+
 	}
 
 	IStructuredModel model = null;
-	
+
 	public StructuredModelWrapper() {
 	}
-	
+
 	public void init(IDocument id) {
 		model = getModelManager().getExistingModelForRead(id);
 	}
@@ -58,25 +67,25 @@ public class StructuredModelWrapper {
 	public void init(IFile file) throws IOException, CoreException {
 		model = getModelManager().getModelForRead(file);
 	}
-	
+
 	public Document getDocument() {
 		return (model instanceof IDOMModel) ? ((IDOMModel) model).getDocument() : null;
 	}
-	
+
 	public XModel getXModel() {
 		return AbstractHyperlink.getXModel(model);
 	}
-	
+
 	public IFile getFile() {
 		return AbstractHyperlink.getFile(model);
 	}
-	
+
 	public String getBaseLocation() {
 		return AbstractHyperlink.getBaseLocation(model);
 	}
-	
+
 	public void dispose() {
-		if(model != null) {
+		if (model != null) {
 			model.releaseFromRead();
 			model = null;
 		}
@@ -85,16 +94,15 @@ public class StructuredModelWrapper {
 	protected IModelManager getModelManager() {
 		return StructuredModelManager.getModelManager();
 	}
-	
+
 	public String getContentTypeIdentifier() {
 		return model.getContentTypeIdentifier();
 	}
 
 	/**
 	 * Static method to execute command with IDOMModel instance provided for
-	 * file. Method obtains structured model instance from StructuredModelManager and release
-	 * it in final block.
-	 * <code><pre>
+	 * file. Method obtains structured model instance from
+	 * StructuredModelManager and release it in final block. <code><pre>
 	 * final List&lt;TextProposal&gt; proposals = new ArrayList&lt;TextProposal&gt;();
 	 * IFile file = context.getResource();
 	 * StructuredModelWrapper.execute(file, new Command() {
@@ -104,16 +112,19 @@ public class StructuredModelWrapper {
 	 *     }
 	 * });
 	 * </pre></code>
-	 * @param file - file to get IDOMDocument instance for 
-	 * @param command - command to execute
+	 * 
+	 * @param file
+	 *            - file to get IDOMDocument instance for
+	 * @param command
+	 *            - command to execute
 	 */
 	public static void execute(IFile file, final ICommand command) {
 		IStructuredModel model = null;
 		try {
 			model = StructuredModelManager.getModelManager().getModelForRead(file);
-			if(model instanceof IDOMModel) {
+			if (model instanceof IDOMModel) {
 				final IDOMDocument xmlDocument = ((IDOMModel) model).getDocument();
-				if(xmlDocument != null) {
+				if (xmlDocument != null) {
 					command.execute(xmlDocument);
 				}
 			}
@@ -126,5 +137,67 @@ public class StructuredModelWrapper {
 				model.releaseFromRead();
 			}
 		}
+	}
+
+	public static <T> T execute(IFile file, final ICommand2<T> command) {
+		IStructuredModel model = null;
+		T result = null;
+		try {
+			model = StructuredModelManager.getModelManager().getModelForRead(file);
+			if (model != null) {
+				result = command.execute(model);
+			}
+		} catch (IOException e) {
+			ExtensionsPlugin.getDefault().logError(e);
+		} catch (CoreException e) {
+			ExtensionsPlugin.getDefault().logError(e);
+		} finally {
+			if (model != null) {
+				model.releaseFromRead();
+			}
+		}
+		return result;
+	}
+
+	public static <T> T execute(IDocument document, final ICommand2<T> command) {
+		IStructuredModel model = null;
+		T result = null;
+		try {
+			// FIXME This method is known to have problems in multi-threading environment
+			//       it should be reported to sse to be fixed
+			model = StructuredModelManager.getModelManager().getExistingModelForRead(document);
+			if (model != null) {
+				result = command.execute(model);
+			}
+		} finally {
+			if (model != null) {
+				model.releaseFromRead();
+			}
+		}
+		return result;
+	}
+
+	public static String getBaseLocation(IDocument document) {
+		return execute(document, sModel -> AbstractHyperlink.getBaseLocation(sModel));
+	}
+
+	public static IFile getFile(IDocument document) {
+		return execute(document, sModel -> AbstractHyperlink.getFile(sModel));
+	}
+
+	public static XModel getXModel(IDocument document) {
+		return execute(document,sModel -> AbstractHyperlink.getXModel(sModel));
+	}
+
+	public static Node getNode(IDocument document, final int superOffset) {
+		return execute(document, sModel -> {
+				Node result = null;
+				if (sModel instanceof IDOMModel) {
+					final IDOMDocument tmpDoc = ((IDOMModel) sModel).getDocument();
+					result = Utils.findNodeForOffset(tmpDoc, superOffset);
+				}	
+				return result;
+			}
+		);
 	}
 }

--- a/common/tests/org.jboss.tools.common.text.ext.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.text.ext.test/META-INF/MANIFEST.MF
@@ -8,8 +8,9 @@ Require-Bundle: org.junit;bundle-version="4.12.0";visibility:=reexport,
  org.jboss.tools.common.text.ext;bundle-version="3.6.0",
  org.eclipse.wst.xml.core;bundle-version="1.1.800",
  org.eclipse.core.resources;bundle-version="3.9.0",
- org.eclipse.core.runtime;bundle-version="3.10.0"
+ org.eclipse.core.runtime;bundle-version="3.10.0",
+ org.jboss.tools.tests.test;bundle-version="3.7.0"
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Bundle-ClassPath: .
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Import-Package: org.jboss.tools.test.util

--- a/common/tests/org.jboss.tools.common.text.ext.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.text.ext.test/pom.xml
@@ -12,4 +12,16 @@
 	<properties>
 		<emma.instrument.bundles>org.jboss.tools.common.model,org.jboss.tools.common.text.ext,org.jboss.tools.common.text.xml</emma.instrument.bundles>
 	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tychoVersion}</version>
+				<configuration>
+					<useUIHarness>false</useUIHarness>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/common/tests/org.jboss.tools.common.text.ext.test/src/org/jboss/tools/common/text/ext/test/StructuredModelWrapperTest.java
+++ b/common/tests/org.jboss.tools.common.text.ext.test/src/org/jboss/tools/common/text/ext/test/StructuredModelWrapperTest.java
@@ -1,0 +1,84 @@
+package org.jboss.tools.common.text.ext.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.jboss.tools.common.text.ext.util.StructuredModelWrapper;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class StructuredModelWrapperTest {
+
+	@BeforeClass
+	public static void createProject() throws InvocationTargetException, IOException, CoreException, InterruptedException {
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("smtest");
+		project.create(null);
+		project.open(null);
+		IFile xmlFile = project.getFile("test1.xml");
+		xmlFile.create(
+				new ByteArrayInputStream(
+						("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
+						"<root/>").getBytes()), 
+						IResource.FORCE, null);
+		IFile htmlFile = project.getFile("test1.html");
+		htmlFile.create(
+				new ByteArrayInputStream(
+						("<!DOCTYPE html>\n" +
+								"<html ng-app=\"test\">\n" +
+								"<body>\n" +
+								"</body>\n" +
+								"</html>").getBytes()), 
+						IResource.FORCE, null);
+	}
+
+	@Test
+	public void testExecuteForHtmlDocument() {
+		IFile testFile = ResourcesPlugin.getWorkspace().getRoot().getProject("smtest").getFile("test1.html");
+		StructuredModelWrapper.execute(testFile, xmlDocument -> assertNotNull(xmlDocument));
+	}
+
+	@Test
+	public void testExecuteForXmlDocument() {
+		IFile testFile = ResourcesPlugin.getWorkspace().getRoot().getProject("smtest").getFile("test1.xml");
+		StructuredModelWrapper.execute(testFile, xmlDocument -> assertNotNull(xmlDocument));
+	}
+
+	@Test
+	public void testExecuteForXmlDocumentICommand2() {
+		IFile testFile = ResourcesPlugin.getWorkspace().getRoot().getProject("smtest").getFile("test1.xml");
+		String result = StructuredModelWrapper.execute(testFile, model -> {
+				assertNotNull(model);
+				return model.getStructuredDocument()
+						.getFirstStructuredDocumentRegion()
+						.getNext() // <?xml ...>
+						.getNext() // '\n'
+						.getText();// <root/> 
+				});
+		assertNotNull(result);
+		assertEquals("<root/>",result);
+	}
+
+	@AfterClass
+	public static void removeProject() {
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("smtest");
+		try {
+			project.delete(IResource.FORCE, null);
+		} catch (CoreException e) {
+			IStatus status = new Status(IStatus.ERROR,"org.jboss.tools.common.text.ext.test","Could not remove test project");
+			Platform.getLog(Platform.getBundle("org.jboss.tools.common.text.ext.test")).log(status);
+		}
+	}
+}

--- a/common/tests/org.jboss.tools.common.text.ext.test/src/org/jboss/tools/common/text/ext/test/TextExtAllTests.java
+++ b/common/tests/org.jboss.tools.common.text.ext.test/src/org/jboss/tools/common/text/ext/test/TextExtAllTests.java
@@ -10,20 +10,11 @@
  ******************************************************************************/ 
 package org.jboss.tools.common.text.ext.test;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-
+@RunWith (Suite.class)
+@Suite.SuiteClasses({UtilsTest.class,StructuredModelWrapperTest.class})
 public class TextExtAllTests {
 	public static final String PLUGIN_ID = "org.jboss.tools.common.text.ext"; //$NON-NLS-1$
-
-	public static Test suite() {
-		TestSuite suite = new TestSuite();
-		suite.setName("All tests for " + PLUGIN_ID); //$NON-NLS-1$
-
-		suite.addTestSuite(UtilsTest.class);
-
-		return suite;
-	}
-
 }


### PR DESCRIPTION
StructuredModelWrapper update to allow return result from command.
Fix contains new Command2<T> class with T execute(IStructuredModel model) method
to allow return an object from the command. That way tricks with passing return through
final local array variable are not required anymore.