### PR TITLE
[JBIDE-21067] Error Log view is polluted with NullPointerExceptions

### DIFF
--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/util/EclipseResourceUtil.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/util/EclipseResourceUtil.java
@@ -365,7 +365,9 @@ public class EclipseResourceUtil extends EclipseUtil {
 					(r.getParent() != null && r.getParent().getParent() != null && r.getParent().getParent().isVirtual()))) r = r.getParent();
 		}
 		if(r == null) return null;
-		properties.setProperty(XModelConstants.WORKSPACE, (r == project ? r : r.getParent()).getLocation().toString());
+		IPath tempLocation = (r == project ? r : r.getParent()).getLocation();
+		if(tempLocation == null) return null;
+		properties.setProperty(XModelConstants.WORKSPACE, tempLocation.toString());
 		properties.setProperty(IModelNature.ECLIPSE_PROJECT, project.getLocation().toString());
 		properties.put(XModelObjectConstants.PROJECT, project);
 		properties.put("isProjectFragment", XModelObjectConstants.TRUE); //$NON-NLS-1$


### PR DESCRIPTION
IResource.getLocation() can return null and returned value should be
checked for null before continue