### PR TITLE
JBIDE-21358 - ensure processIsRunning only throws exceptions when critical

### DIFF
--- a/common/plugins/org.jboss.tools.common.jdt.debug/src/org/jboss/tools/common/jdt/debug/RemoteDebugActivator.java
+++ b/common/plugins/org.jboss.tools.common.jdt.debug/src/org/jboss/tools/common/jdt/debug/RemoteDebugActivator.java
@@ -163,13 +163,13 @@ public class RemoteDebugActivator extends BaseCorePlugin implements IPropertyCha
 		if (monitor.isCanceled()) {
 			return null;
 		}
-		boolean running = false;
+		boolean monitorable = false;
 		try {
-			running = ToolsCore.processIsRunning(hostname, vmPid);
+			monitorable = ToolsCore.processIsMonitorable(hostname, vmPid);
 		} catch(ToolsCoreException c ) {
 			pluginLog().logWarning(c);
 		}
-		if( running ) {
+		if( monitorable ) {
 			VmModel model = new VmModel();
 			model.setPid(String.valueOf(vmPid));
 			// If process is suspended (launched with suspend=y waiting for debugger) these may fail...

--- a/common/plugins/org.jboss.tools.common.jdt.debug/src/org/jboss/tools/common/jdt/debug/tools/ToolsCore.java
+++ b/common/plugins/org.jboss.tools.common.jdt.debug/src/org/jboss/tools/common/jdt/debug/tools/ToolsCore.java
@@ -16,6 +16,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.eclipse.jdt.launching.IVMInstall;
+import org.jboss.tools.common.jdt.debug.tools.internal.IToolsConstants;
 import org.jboss.tools.common.jdt.debug.tools.internal.Tools;
 
 /**
@@ -94,8 +95,32 @@ public class ToolsCore {
 		return Tools.getInstance().invokeActiveVms(hostname);
 	}
 	
+	/**
+	 * This method was poorly named and is is instead desired to return whether a process
+	 * is able to be monitored or not. 
+	 * 
+	 * @param hostname
+	 * @param vmPid
+	 * @return
+	 * @throws ToolsCoreException
+	 */
+	@Deprecated
 	public static boolean processIsRunning(String hostname, int vmPid) throws ToolsCoreException {
-		return Tools.getInstance().getMonitoredVm(hostname, vmPid) != null;
+		return processIsMonitorable(hostname, vmPid);
+	}
+	
+	public static boolean processIsMonitorable(String hostname, int vmPid) throws ToolsCoreException {
+		// If these throw exceptions, we want them to be rethrown and logged
+		Object host = Tools.getInstance().invokeGetMonitoredHost(hostname);
+		Object vmId = Tools.getInstance().invokeVmIdentifier(String.format(IToolsConstants.VM_IDENTIFIRER, vmPid));
+		
+		try {
+			// We want to catch and ignore these failures and just return that the process is able to be monitored
+			Object monitoredVm = Tools.getInstance().invokeGetMonitoredVm(host, vmId);
+			return monitoredVm != null;
+		} catch(ToolsCoreException tce) {
+			return false;
+		}
 	}
 
 	public static String getJvmArgs(String hostname, int vmPid) throws ToolsCoreException {


### PR DESCRIPTION
Ensure processIsRunning only throws exceptions when critical