### PR TITLE
JBIDE-21302 Removing user from credentials framework while not authenticated to secure storage should not work

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/credentials/ICredentialsModel.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/credentials/ICredentialsModel.java
@@ -67,7 +67,8 @@ public interface ICredentialsModel {
 	
 	/**
 	 * Return whether this credential requires a prompt on every occasion
-	 * @param domain
+	 * @param domain	@Override
+
 	 * @param user
 	 * @return
 	 */
@@ -102,6 +103,15 @@ public interface ICredentialsModel {
 	
 	/**
 	 * Save the credential model in secure storage
+	 * @deprecated Use save() instead.
 	 */
+	@Deprecated
 	public void saveModel();
+
+	/**
+	 * Save the credential model in secure storage
+	 * Returns false if user failed to provide password for the secure storage.
+	 * @return
+	 */
+	public boolean save();
 }

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/credentials/internal/CredentialsModel.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/credentials/internal/CredentialsModel.java
@@ -236,9 +236,14 @@ public class CredentialsModel implements ICredentialsModel {
 		return (ICredentialDomain[]) domains.toArray(new ICredentialDomain[domains.size()]);
 	}
 	
-	
-	
+
+	@Override
 	public void saveModel() {
+		save();
+	}
+	
+	@Override
+	public boolean save() {
 		try {
 			ISecurePreferences secureRoot = SecurePreferencesFactory.getDefault();
 			ISecurePreferences secureCredentialRoot = secureRoot.node(CREDENTIAL_BASE_KEY);
@@ -267,6 +272,9 @@ public class CredentialsModel implements ICredentialsModel {
 			credentialRoot.flush();
 			secureCredentialRoot.flush();
 		} catch(StorageException se) {
+			if(se.getErrorCode() == StorageException.NO_PASSWORD) {
+				return false;
+			}
 			// TODO logging
 			se.printStackTrace();
 		} catch(IOException ioe) {
@@ -276,6 +284,7 @@ public class CredentialsModel implements ICredentialsModel {
 			// TODO logging
 			bse.printStackTrace();
 		}
+		return true;
 	}
 	
 	IEclipsePreferences getPreferences() {

--- a/foundation/plugins/org.jboss.tools.foundation.ui/src/org/jboss/tools/foundation/ui/credentials/ChooseCredentialComponent.java
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/src/org/jboss/tools/foundation/ui/credentials/ChooseCredentialComponent.java
@@ -136,7 +136,7 @@ public class ChooseCredentialComponent {
 			} else {
 				CredentialService.getCredentialModel().addCredentials(cd, name, pass);
 			}
-			CredentialService.getCredentialModel().saveModel();
+			CredentialService.getCredentialModel().save();
 			refreshUserCombo(name, true);
 		}
 	}

--- a/foundation/plugins/org.jboss.tools.foundation.ui/src/org/jboss/tools/foundation/ui/credentials/internal/CredentialMessages.java
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/src/org/jboss/tools/foundation/ui/credentials/internal/CredentialMessages.java
@@ -26,6 +26,8 @@ public class CredentialMessages {
 	public static String DomainNameExists;
 	public static String DomainIdExists;
 	public static String NewDomainNameLabel;
+	public static String Warning;
+	public static String UnableToDeleteCredentials;
 	
 	public static String DomainLabel;
 	public static String AddACredentialLabel;

--- a/foundation/plugins/org.jboss.tools.foundation.ui/src/org/jboss/tools/foundation/ui/credentials/internal/CredentialMessages.properties
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/src/org/jboss/tools/foundation/ui/credentials/internal/CredentialMessages.properties
@@ -8,6 +8,8 @@ EditACredentialDomain=Edit a Credential Domain
 DomainNameExists=A domain with that name already exists
 DomainIdExists=A domain with that ID already exists
 NewDomainNameLabel=Name:
+Warning=Warning
+UnableToDeleteCredentials=Unable to delete credentials stored in secure storage without authenticating to secure storage
 
 DomainLabel=Domain: 
 AddACredentialLabel=Add a Credential

--- a/foundation/plugins/org.jboss.tools.foundation.ui/src/org/jboss/tools/foundation/ui/credentials/internal/CredentialPreferencePage.java
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/src/org/jboss/tools/foundation/ui/credentials/internal/CredentialPreferencePage.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.Comparator;
 
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -285,7 +286,7 @@ public class CredentialPreferencePage extends PreferencePage implements IWorkben
 		if( dialog.open() == Window.OK) {
 			String name = dialog.getDomainName();
 			CredentialService.getCredentialModel().addDomain(name, name, true);
-			CredentialService.getCredentialModel().saveModel();
+			CredentialService.getCredentialModel().save();
 			tv.refresh();
 		}
 	}
@@ -295,8 +296,16 @@ public class CredentialPreferencePage extends PreferencePage implements IWorkben
 		if( selected instanceof ICredentialDomain) {
 			ICredentialDomain domain = (ICredentialDomain)selected;
 			if( domain.getRemovable() && domain.getUsernames().length == 0) {
+				if(!CredentialService.getCredentialModel().save()) {
+					//Is not able to save model, because user does not authenticated sequre storage. 
+					//Do not complete remove.
+					MessageDialog.openWarning(removeUserButton.getShell(), 
+							CredentialMessages.Warning, 
+							CredentialMessages.UnableToDeleteCredentials);
+					return;
+				}
 				CredentialService.getCredentialModel().removeDomain(domain);
-				CredentialService.getCredentialModel().saveModel();
+				CredentialService.getCredentialModel().save();
 				tv.refresh();
 			}
 		}
@@ -317,7 +326,7 @@ public class CredentialPreferencePage extends PreferencePage implements IWorkben
 				getShell(), CredentialService.getCredentialModel(), domain);
 		if( dialog.open() == Window.OK) {
 			CredentialService.getCredentialModel().setDefaultCredential(domain, dialog.getDefaultUser());
-			CredentialService.getCredentialModel().saveModel();
+			CredentialService.getCredentialModel().save();
 			tv.refresh();
 		}
 
@@ -335,7 +344,7 @@ public class CredentialPreferencePage extends PreferencePage implements IWorkben
 			} else {
 				CredentialService.getCredentialModel().addCredentials(u.domain, name, pass);
 			}
-			CredentialService.getCredentialModel().saveModel();
+			CredentialService.getCredentialModel().save();
 			tv.refresh();
 		}
 	}
@@ -360,19 +369,27 @@ public class CredentialPreferencePage extends PreferencePage implements IWorkben
 			} else {
 				CredentialService.getCredentialModel().addCredentials(cd, name, pass);
 			}
-			CredentialService.getCredentialModel().saveModel();
+			CredentialService.getCredentialModel().save();
 			tv.refresh();
 		}
 
 	}
-	
+
 	private void removeUserPressed() {
 		IStructuredSelection ss = (IStructuredSelection)tv.getSelection();
 		Object selected = ss.getFirstElement();
 		if( selected instanceof CredentialUser) {
+			if(!CredentialService.getCredentialModel().save()) {
+				//Is not able to save model, because user does not authenticated sequre storage. 
+				//Do not complete remove.
+				MessageDialog.openWarning(removeUserButton.getShell(), 
+						CredentialMessages.Warning, 
+						CredentialMessages.UnableToDeleteCredentials);
+				return;
+			}
 			CredentialService.getCredentialModel().removeCredentials(
 					((CredentialUser)selected).domain, ((CredentialUser)selected).user);
-			CredentialService.getCredentialModel().saveModel();
+			CredentialService.getCredentialModel().save();
 			tv.refresh();
 		}
 	}


### PR DESCRIPTION
Call CredentialService.getCredentialModel().saveModel() before removal is done.
That triggers authentication to secure storage if it has not been done yet.
By returning boolean in saveModel() equal to false if user failed to authenticate,
we can abort removing credentials.