### PR TITLE
Fix test errors on systems without browser available

### DIFF
--- a/foundation/tests/org.jboss.tools.foundation.ui.test/src/org/jboss/tools/foundation/ui/test/BrowserUtilTest.java
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/src/org/jboss/tools/foundation/ui/test/BrowserUtilTest.java
@@ -48,6 +48,6 @@ public class BrowserUtilTest{
 		b = new BrowserUtility().createBrowserOrLink(SWT.NONE, new Shell(), SWT.WEBKIT,
 				provider, "No Browser");
 		Assert.assertNotNull(b);
-		Assert.assertTrue(b instanceof Browser);
+		Assert.assertTrue(b instanceof Browser || b instanceof Link);
 	}
 }


### PR DESCRIPTION
If browser is not available test should check for Link instance
as well in latest check