### PR TITLE
JBIDE-22691 - Allow extensions to be injected with Eclipse services

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Export-Package: org.jboss.tools.foundation.core,
  org.jboss.tools.foundation.core.digest,
  org.jboss.tools.foundation.core.ecf,
  org.jboss.tools.foundation.core.expressions,
+ org.jboss.tools.foundation.core.ext,
  org.jboss.tools.foundation.core.internal;x-friends:="org.jboss.tools.foundation.core.test",
  org.jboss.tools.foundation.core.jobs,
  org.jboss.tools.foundation.core.plugin,
@@ -29,7 +30,9 @@ Require-Bundle: org.eclipse.equinox.p2.core;bundle-version="2.2.0",
  org.eclipse.ecf.filetransfer;bundle-version="5.0.0",
  org.eclipse.ecf.provider.filetransfer;bundle-version="3.2.0",
  org.eclipse.ecf.provider.filetransfer.httpclient4;bundle-version="1.0.300",
- org.jboss.tools.foundation.checkup
+ org.jboss.tools.foundation.checkup,
+ org.eclipse.e4.core.contexts;bundle-version="1.5.0",
+ org.eclipse.e4.core.di;bundle-version="1.6.0"
 Bundle-Version: 1.3.1.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/ext/AbstractExtensionFactory.java
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/ext/AbstractExtensionFactory.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.core.ext;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExecutableExtension;
+import org.eclipse.core.runtime.IExecutableExtensionFactory;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.osgi.framework.Bundle;
+
+/**
+ * Base workbench extension factory. 
+ * 
+ * By default, extensions are created using the {@link ContextInjectionFactory}, 
+ * and are re-injected into the same {@link IEclipseContext} they were created from.
+ */
+public abstract class AbstractExtensionFactory implements IExecutableExtension, IExecutableExtensionFactory {
+	
+	protected IConfigurationElement config;
+	protected String data;
+	protected String propertyName;
+
+	@Override
+	public Object create() throws CoreException {
+		try {
+			return configureInstance(getInstance());
+		}
+		catch (Exception e) {
+			throw new CoreException(new Status(IStatus.ERROR, getBundle().getSymbolicName(), e.getMessage() + 
+					" AbstractExtensionFactory: "+ getClass().getName(), e));
+		}
+	}
+	
+	private Object configureInstance(Object instance) throws CoreException {
+		if (instance instanceof IExecutableExtension) {
+			((IExecutableExtension) instance).setInitializationData(config, propertyName, null);
+		}
+		return instance;
+	}
+	
+	@Override
+	public void setInitializationData(IConfigurationElement config, String propertyName, Object data)
+		throws CoreException {
+		if (!(data instanceof String)) {
+			throw new IllegalArgumentException("Data argument must be a String for " + getClass()); //$NON-NLS-1$
+		}
+		this.data = (String) data;
+		this.propertyName = propertyName;
+		this.config = config;
+	}
+	
+	/**
+	 * Creates the extension from an IEclipseContext and injects it into the context.
+	 * 
+	 * @return the extension instance.
+	 */
+	protected Object getInstance() throws Exception {
+		Class<?> clazz = getBundle().loadClass(data);
+		IEclipseContext ctx = getContext();
+		Object result = ContextInjectionFactory.make(clazz, ctx);
+		ctx.set(clazz.toString(), result);
+		return result;
+	}
+	
+	/**
+	 * @return the bundle used for loading the extension.
+	 */
+	protected abstract Bundle getBundle();
+	
+	/**
+	 * @return the context to create and inject the extension from/to.
+	 */
+	protected abstract IEclipseContext getContext();
+}

--- a/foundation/plugins/org.jboss.tools.foundation.ui/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/META-INF/MANIFEST.MF
@@ -10,12 +10,15 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.9.0",
  org.jboss.tools.foundation.core;bundle-version="1.1.0",
  org.eclipse.ui;bundle-version="3.105.0",
  org.eclipse.equinox.security;bundle-version="1.2.100",
- org.eclipse.ui.forms;bundle-version="3.6.0"
+ org.eclipse.ui.forms;bundle-version="3.6.0",
+ org.eclipse.e4.ui.model.workbench;bundle-version="1.2.0",
+ org.eclipse.e4.core.contexts;bundle-version="1.5.0"
 Bundle-Version: 1.3.1.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.tools.foundation.ui.credentials,
+ org.jboss.tools.foundation.ui.ext,
  org.jboss.tools.foundation.ui.jobs,
  org.jboss.tools.foundation.ui.plugin,
  org.jboss.tools.foundation.ui.util,

--- a/foundation/plugins/org.jboss.tools.foundation.ui/src/org/jboss/tools/foundation/ui/ext/AbstractUiExtensionFactory.java
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/src/org/jboss/tools/foundation/ui/ext/AbstractUiExtensionFactory.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.ui.ext;
+
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.ui.PlatformUI;
+import org.jboss.tools.foundation.core.ext.AbstractExtensionFactory;
+
+/**
+ * Extension factory for creating extensions from the {@link MApplication} context.
+ */
+public abstract class AbstractUiExtensionFactory extends AbstractExtensionFactory {
+	/**
+	 * @return the application context.
+	 */
+	protected IEclipseContext getContext() {
+		return ((MApplication)PlatformUI.getWorkbench().getService(MApplication.class)).getContext();
+	}
+}

--- a/foundation/tests/org.jboss.tools.foundation.ui.test/META-INF/MANIFEST.MF
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/META-INF/MANIFEST.MF
@@ -1,14 +1,19 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Foundation UI Test
-Bundle-SymbolicName: org.jboss.tools.foundation.ui.test
+Bundle-SymbolicName: org.jboss.tools.foundation.ui.test;singleton:=true
 Bundle-Version: 1.3.1.qualifier
+Bundle-ClassPath: .
 Export-Package: org.jboss.tools.foundation.ui.test
 Require-Bundle: org.junit,
  org.jboss.tools.foundation.ui;bundle-version="1.2.0",
  org.eclipse.swt,
  org.eclipse.jface;bundle-version="3.11.0",
- org.jboss.tools.foundation.core;bundle-version="1.2.0"
+ org.jboss.tools.foundation.core;bundle-version="1.2.0",
+ org.eclipse.osgi,
+ org.eclipse.ui;bundle-version="3.108.0",
+ org.eclipse.core.runtime;bundle-version="3.12.0",
+ org.eclipse.e4.core.contexts;bundle-version="1.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Import-Package: org.eclipse.ui,
- org.jboss.tools.foundation.core
+Bundle-Activator: org.jboss.tools.foundation.ui.test.Activator
+Bundle-ActivationPolicy: lazy

--- a/foundation/tests/org.jboss.tools.foundation.ui.test/build.properties
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/build.properties
@@ -1,3 +1,4 @@
 source.. = src/
 bin.includes = META-INF/,\
-               .
+               .,\
+               plugin.xml

--- a/foundation/tests/org.jboss.tools.foundation.ui.test/plugin.xml
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/plugin.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         id="org.jboss.tools.foundation.ui.test.view.extension"
+         point="org.eclipse.ui.views">
+      <view
+            class="org.jboss.tools.foundation.ui.test.ext.E4ExtensionFactoryTest$TestExtensionFactory:org.jboss.tools.foundation.ui.test.ext.TestView"
+            id="org.jboss.tools.foundation.ui.test.view"
+            name="name"
+            restorable="true">
+      </view>
+   </extension>
+
+</plugin>

--- a/foundation/tests/org.jboss.tools.foundation.ui.test/pom.xml
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/pom.xml
@@ -22,8 +22,8 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tychoVersion}</version>
 				<configuration>
-					<useUIHarness>false</useUIHarness>
-					<useUIThread>false</useUIThread>
+					<useUIHarness>true</useUIHarness>
+					<useUIThread>true</useUIThread>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/foundation/tests/org.jboss.tools.foundation.ui.test/src/org/jboss/tools/foundation/ui/test/Activator.java
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/src/org/jboss/tools/foundation/ui/test/Activator.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.ui.test;
+
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The activator class controls the plug-in life cycle
+ */
+public class Activator extends AbstractUIPlugin {
+
+	// The plug-in ID
+	public static final String PLUGIN_ID = "org.jboss.tools.foundation.ui.test"; //$NON-NLS-1$
+
+	// The shared instance
+	private static Activator plugin;
+	
+	/**
+	 * The constructor
+	 */
+	public Activator() {
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
+	 */
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+	 */
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+		super.stop(context);
+	}
+
+	/**
+	 * Returns the shared instance
+	 *
+	 * @return the shared instance
+	 */
+	public static Activator getDefault() {
+		return plugin;
+	}
+}

--- a/foundation/tests/org.jboss.tools.foundation.ui.test/src/org/jboss/tools/foundation/ui/test/FoundationUITestSuite.java
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/src/org/jboss/tools/foundation/ui/test/FoundationUITestSuite.java
@@ -10,11 +10,13 @@
  ******************************************************************************/ 
 package org.jboss.tools.foundation.ui.test;
 
+import org.jboss.tools.foundation.ui.test.ext.E4ExtensionFactoryTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-	BrowserUtilTest.class })
+	BrowserUtilTest.class,
+	E4ExtensionFactoryTest.class})
 public class FoundationUITestSuite {
 }

--- a/foundation/tests/org.jboss.tools.foundation.ui.test/src/org/jboss/tools/foundation/ui/test/ext/E4ExtensionFactoryTest.java
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/src/org/jboss/tools/foundation/ui/test/ext/E4ExtensionFactoryTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.ui.test.ext;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.Platform;
+import org.jboss.tools.foundation.ui.ext.AbstractUiExtensionFactory;
+import org.jboss.tools.foundation.ui.test.Activator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+
+public class E4ExtensionFactoryTest {
+	
+	public static class TestExtensionFactory extends AbstractUiExtensionFactory {
+		@Override
+		protected Bundle getBundle() {
+			return Activator.getDefault().getBundle();
+		}
+	}
+	
+	@Test
+	public void testExtensionFactory() throws CoreException {
+		IExtension extension = Platform.getExtensionRegistry().getExtension("org.jboss.tools.foundation.ui.test.view.extension");
+		IConfigurationElement element = extension.getConfigurationElements()[0];
+		TestView view = (TestView)element.createExecutableExtension("class");
+		Assert.assertTrue(view.isValid());
+	}
+}

--- a/foundation/tests/org.jboss.tools.foundation.ui.test/src/org/jboss/tools/foundation/ui/test/ext/TestView.java
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/src/org/jboss/tools/foundation/ui/test/ext/TestView.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.foundation.ui.test.ext;
+
+import javax.inject.Inject;
+
+import org.eclipse.core.runtime.preferences.IPreferencesService;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.part.ViewPart;
+
+public class TestView extends ViewPart {
+
+	@Inject private IPreferencesService preferenceService;
+	
+	public boolean isValid() {
+		return preferenceService != null;
+	}
+
+	public void createPartControl(Composite parent) {}
+	@Override
+	public void setFocus() {}
+}


### PR DESCRIPTION
It's common to need access to services from within extensions.