### PR TITLE
JBIDE-22696 use CURRENT timestamp, not git...

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
@@ -29,7 +29,7 @@
 				<version>${tychoVersion}</version>
 				<configuration>
 					<format>'${BUILD_ALIAS}-v'yyyyMMdd-HHmm</format>
-					<timestampProvider></timestampProvider>
+					<timestampProvider>default</timestampProvider>
 				</configuration>
 			</plugin>
 			<!-- get major.minor.incremental from root pom, then use devstudio.version = ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${BUILD_ALIAS} -->


### PR DESCRIPTION
JBIDE-22696 use CURRENT timestamp, not git lastmod timestamp for org.jboss.tools.foundation.core; need to set timestampProvider=default, not timestampProvider=''