### PR TITLE
bump poms to 4.4.2-SNAPSHOT...

### DIFF
--- a/all-tests/pom.xml
+++ b/all-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.4.1-SNAPSHOT</version>
+		<version>4.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.base</groupId>
 	<artifactId>all-tests</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.4.1-SNAPSHOT</version>
+		<version>4.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>common</artifactId>

--- a/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
@@ -33,7 +33,7 @@ Require-Bundle: org.eclipse.equinox.p2.core;bundle-version="2.2.0",
  org.jboss.tools.foundation.checkup,
  org.eclipse.e4.core.contexts;bundle-version="1.5.0",
  org.eclipse.e4.core.di;bundle-version="1.6.0"
-Bundle-Version: 1.3.1.qualifier
+Bundle-Version: 1.3.2.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.foundation.plugins</groupId>
 	<artifactId>org.jboss.tools.foundation.core</artifactId>
-	<version>1.3.1-SNAPSHOT</version>
+	<version>1.3.2-SNAPSHOT</version>
 
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
@@ -8,5 +8,5 @@
 # Contributors:
 #     Red Hat, Inc. - initial API and implementation
 ##############################################################################
-default.version=4.4.1.Alpha1
+default.version=4.4.2.Final
 version=${jbosstools.version}

--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.4.1-SNAPSHOT</version>
+		<version>4.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>foundation</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>base</artifactId>
-	<version>4.4.1-SNAPSHOT</version>
+	<version>4.4.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>jbosstools-base</name>
 	<properties>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.4.1-SNAPSHOT</version>
+		<version>4.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>runtime</artifactId>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.4.1-SNAPSHOT</version>
+		<version>4.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.base</groupId>
 	<artifactId>site</artifactId>

--- a/stacks/pom.xml
+++ b/stacks/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.4.1-SNAPSHOT</version>
+		<version>4.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>stacks</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.4.1-SNAPSHOT</version>
+		<version>4.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>tests</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>base</artifactId>
-		<version>4.4.1-SNAPSHOT</version>
+		<version>4.4.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>usage</artifactId>


### PR DESCRIPTION
bump poms to 4.4.2-SNAPSHOT (JBIDE-23156)

fix currentversion.properties and plugin version of org.jboss.tools.foundation.core