### PR TITLE
Add maven nature to foundation.ui

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.ui/.classpath
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/.classpath
@@ -4,5 +4,5 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="lib" path="lib/magicfile4j-1.0.0-Beta1.jar"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/foundation/plugins/org.jboss.tools.foundation.ui/.project
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/.project
@@ -25,8 +25,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>

--- a/foundation/plugins/org.jboss.tools.foundation.ui/.settings/org.eclipse.m2e.core.prefs
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/foundation/plugins/org.jboss.tools.foundation.ui/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/pom.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion> 
+	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>plugins</artifactId>
 		<version>1.3.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.plugins</groupId>
-	<artifactId>org.jboss.tools.foundation.ui</artifactId> 
-	
+	<artifactId>org.jboss.tools.foundation.ui</artifactId>
+
 	<packaging>eclipse-plugin</packaging>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.7</version><!--$NO-MVN-MAN-VER$-->
 				<executions>
 					<execution>
 						<id>get-libs</id>
@@ -28,7 +27,7 @@
 				<configuration>
 					<skip>false</skip>
 					<outputDirectory>${basedir}/lib/</outputDirectory>
-					<!-- baseVersion is to avoid SNAPSHOT dependencies being copied with 
+					<!-- baseVersion is to avoid SNAPSHOT dependencies being copied with
 						ever daily changing timestamp -->
 					<useBaseVersion>true</useBaseVersion>
 					<artifactItems>


### PR DESCRIPTION
Fix adds maven nature to fondation.ui bundle to fix compilation
errors after importing bundle in eclipse workspace. Without
maven feature bundle have to be built by maven first to download
maven dependencies.
