### PR TITLE
JBIDE-23302 if we don't actually need it, we...

### DIFF
--- a/usage/plugins/org.jboss.tools.usage/plugin.xml
+++ b/usage/plugins/org.jboss.tools.usage/plugin.xml
@@ -41,7 +41,7 @@
          </link>
          <!-- test that redirects to https://redhat.ctrlflow.com/rest/2.0/community/discovery" -->
          <link
-               href="https://tools.jboss.org/usage/errors/rest/2.0/community/discovery" 
+               href="http://tools.jboss.org/usage/errors/rest/2.0/community/discovery" 
                rel="discovery"
                title="Discovery URL">
          </link>


### PR DESCRIPTION
JBIDE-23302 if we don't actually need it, we could switch to http instead of http for the AERI discovery/redirect to https://aer.ctrlflow.com/redhat/community/discovery
