### PR TITLE
JBDS-4014 Add a facility to pick up and report on RPM (or any OS package

### DIFF
--- a/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/googleanalytics/eclipse/EclipseUserAgent.java
+++ b/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/googleanalytics/eclipse/EclipseUserAgent.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.jboss.tools.usage.googleanalytics.eclipse;
 
+import java.io.File;
+import java.net.URL;
 import java.text.MessageFormat;
 
 import org.eclipse.core.runtime.IProduct;
@@ -135,7 +137,12 @@ public class EclipseUserAgent implements IEclipseUserAgent {
 	}
 
 	public String getApplicationName() {
-		return getApplicationBundle().getSymbolicName();
+		String pkgs = getInstalledPkgs();
+		if (pkgs != null && !pkgs.isEmpty()) {
+			return getApplicationBundle().getSymbolicName() + "|" + pkgs;
+		} else {
+			return getApplicationBundle().getSymbolicName();
+		}
 	}
 
 	public String getApplicationVersion() {
@@ -146,6 +153,33 @@ public class EclipseUserAgent implements IEclipseUserAgent {
 		} else {
 			return fullVersion;
 		}
+	}
+
+	/**
+	 * Gets the list of packages installed by the OS's package management
+	 * system. OS packages (RPMs, DEBs, whatever) that we want to track
+	 * installation of, should install marker files into ${eclipse_home}/.pkgs
+	 * to be detected here.
+	 * 
+	 * @return a comma delimited string
+	 */
+	private String getInstalledPkgs() {
+		StringBuilder pkgs = new StringBuilder();
+		URL installLoc = Platform.getInstallLocation().getURL();
+		File pkgDir = new File(installLoc.getFile(), ".pkgs");
+		if (pkgDir.isDirectory()) {
+			File[] files = pkgDir.listFiles();
+			for (int i = 0; i < files.length; i++) {
+				if (files[i].isFile()) {
+					if (pkgs.length() > 0) {
+						pkgs.append("," + files[i].getName());
+					} else {
+						pkgs.append(files[i].getName());
+					}
+				}
+			}
+		}
+		return pkgs.toString();
 	}
 
 	/**

--- a/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/preferences/PreferencesMessages.java
+++ b/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/preferences/PreferencesMessages.java
@@ -26,6 +26,7 @@ public class PreferencesMessages extends NLS {
 	public static String UsageReportPreferencePage_OperatingSystem;
 	public static String UsageReportPreferencePage_OperatingSystemVersion;
 	public static String UsageReportPreferencePage_LinuxDistro;
+	public static String UsageReportPreferencePage_InstalledPkgs;
 	public static String UsageReportPreferencePage_ProductId;
 	public static String UsageReportPreferencePage_ProductOwner;
 	public static String UsageReportPreferencePage_ProductVersion;

--- a/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/preferences/UsageReportPreferencePage.java
+++ b/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/preferences/UsageReportPreferencePage.java
@@ -90,8 +90,9 @@ public class UsageReportPreferencePage extends FieldEditorPreferencePage impleme
 		builder.append(StringUtils.getLineSeparator());
 
 		IEclipseUserAgent eclipseUserAgent = eclipseEnvironment.getEclipseUserAgent();
+		String appName[] = eclipseUserAgent.getApplicationName().split("\\|", 2);
 		appendLabeledValue(PreferencesMessages.UsageReportPreferencePage_ProductId,
-				eclipseUserAgent.getApplicationName(), builder, styles);
+				appName[0], builder, styles);
 
 		appendLabeledValue(PreferencesMessages.UsageReportPreferencePage_ProductVersion,
 				eclipseUserAgent.getApplicationVersion(), builder, styles);
@@ -104,6 +105,10 @@ public class UsageReportPreferencePage extends FieldEditorPreferencePage impleme
 		if (eclipseEnvironment.isLinuxDistro()) {
 			appendLabeledValue(PreferencesMessages.UsageReportPreferencePage_LinuxDistro,
 					eclipseEnvironment.getUserDefined(), builder, styles);
+		}
+		if (appName.length > 1) {
+			appendLabeledValue(PreferencesMessages.UsageReportPreferencePage_InstalledPkgs,
+					appName[1], builder, styles);
 		}
 		builder.append(StringUtils.getLineSeparator());
 

--- a/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/preferences/messages.properties
+++ b/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/preferences/messages.properties
@@ -20,6 +20,7 @@ UsageReportPreferencePage_NumberOfUsageHits=Number of usage-hits\:
 UsageReportPreferencePage_OperatingSystem=Operating system\: 
 UsageReportPreferencePage_OperatingSystemVersion=Operating system version\: 
 UsageReportPreferencePage_LinuxDistro=Linux Distro\: 
+UsageReportPreferencePage_InstalledPkgs=Installed packages\: 
 
 UsageReportPreferencePage_JvmName=JVM name\: 
 UsageReportPreferencePage_JvmVersion=JVM version\: 

--- a/usage/tests/org.jboss.tools.usage.test/META-INF/MANIFEST.MF
+++ b/usage/tests/org.jboss.tools.usage.test/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.jboss.tools.usage;bundle-version="1.0.0",
  org.eclipse.osgi;bundle-version="3.5.2",
  org.eclipse.core.runtime;bundle-version="3.5.0",
  org.junit;bundle-version="[4.8.1,5.0.0)",
- org.eclipse.jface;bundle-version="3.10.0"
+ org.eclipse.jface;bundle-version="3.10.0",
+ org.hamcrest.core;bundle-version="1.3.0"
 Bundle-Activator: org.jboss.tools.usage.test.JBossToolsUsageTestActivator
 Bundle-ActivationPolicy: lazy
 Import-Package: org.jboss.tools.common.log


### PR DESCRIPTION
manager) installed packages. Product ID is sent back augmented
with a comma delimited list of such packages.

To make use of this, the OS installed packages that we are
interested in must deliver a file into $eclipse_home/.pkgs
as part of its payload.