### PR TITLE
JBDS-4191 remove dependency on...

### DIFF
--- a/common/tests/org.jboss.tools.common.mylyn.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.mylyn.test/META-INF/MANIFEST.MF
@@ -12,11 +12,7 @@ Require-Bundle: org.jboss.tools.common.mylyn,
  org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.mylyn.bugzilla.core;bundle-version="3.6.0",
  org.eclipse.mylyn.bugzilla.ide;bundle-version="3.6.0",
- org.eclipse.mylyn.bugzilla.ui;bundle-version="3.6.0",
- com.atlassian.connector.eclipse.commons.core;bundle-version="3.0.0";resolution:=optional;x-installation:=greedy,
- com.atlassian.connector.eclipse.commons.ui;bundle-version="3.0.0";resolution:=optional;x-installation:=greedy,
- com.atlassian.connector.eclipse.jira.core;bundle-version="3.0.0";resolution:=optional;x-installation:=greedy,
- com.atlassian.connector.eclipse.jira.ui;bundle-version="3.0.0";resolution:=optional;x-installation:=greedy
+ org.eclipse.mylyn.bugzilla.ui;bundle-version="3.6.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
JBDS-4191 remove dependency on com.atlassian.connector.eclipse.* since we no longer ship that in Central (in tests)

Signed-off-by: nickboldt <nboldt@redhat.com>