### PR TITLE
JBIDE-23677 enable maven enforcer test to...

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
@@ -66,6 +66,35 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.4.1</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.jboss.tools.releng</groupId>
+						<artifactId>enforcer-rules</artifactId>
+						<version>${jbossTychoPluginsVersion}</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>foundation-core-default-version-check</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<foundationCoreVersionMatchesParentPom implementation="org.jboss.tools.releng.FoundationCoreVersionMatchesParentPom">
+									<currentVersionProperties>src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties</currentVersionProperties>
+								</foundationCoreVersionMatchesParentPom>
+							</rules>
+							<!-- warn but continue the build when fail = false -->
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014 Red Hat, Inc.
+# Copyright (c) 2014-2017 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -8,5 +8,6 @@
 # Contributors:
 #     Red Hat, Inc. - initial API and implementation
 ##############################################################################
+# set default.version to the same x.y.z base as the parent pom, then .${BUILD_ALIAS} or .Final
 default.version=4.4.3.Final
 version=${jbosstools.version}


### PR DESCRIPTION
JBIDE-23677 enable maven enforcer test to ensure we set correct version of foundation.core (based on parent pom version)

Signed-off-by: nickboldt <nboldt@redhat.com>