### PR TITLE
JBIDE-23677 use parent pom to define jbosstools.version -> currentver…

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
@@ -44,7 +44,7 @@
 							<goal>parse-version</goal>
 						</goals>
 						<configuration>
-							<versionString>${project.parent.parent.parent.version}</versionString>
+							<versionString>${project.parent.parent.parent.parent.version}</versionString>
 						</configuration>
 					</execution>
 				</executions>
@@ -87,8 +87,8 @@
 						<configuration>
 							<rules>
 								<foundationCoreVersionMatchesParentPom implementation="org.jboss.tools.releng.FoundationCoreVersionMatchesParentPom">
-									<!-- JBIDE-23677 temporary workaround: set parent pom version here because it's not being computed correctly from root pom version -->
-									<parentPomVersionBase>4.4.4.SNAPSHOT</parentPomVersionBase>
+									<!-- can override parent pom version here if required -->
+									<!-- <parentPomVersionBase>4.4.4.SNAPSHOT</parentPomVersionBase> -->
 									<currentVersionProperties>src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties</currentVersionProperties>
 								</foundationCoreVersionMatchesParentPom>
 							</rules>
@@ -169,7 +169,7 @@
 		</pluginManagement>
 	</build>
 	<properties>
-		<!-- inherit from root pom version, eg., 4.4.0-SNAPSHOT -->
+		<!-- inherit from root pom version, eg., 4.4.4.AM1-SNAPSHOT -->
 		<jbosstools.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${BUILD_ALIAS}</jbosstools.version>
 		<local.config.properties.dir>src/org/jboss/tools/foundation/core/properties/internal/</local.config.properties.dir>
 	</properties>


### PR DESCRIPTION
…sion.properties, not root pom

Signed-off-by: nickboldt <nboldt@redhat.com>