### PR TITLE
JBIDE-23833 more complete solution to remove JIRA support from org.jb…

### DIFF
--- a/common/features/org.jboss.tools.common.all.test.feature/feature.xml
+++ b/common/features/org.jboss.tools.common.all.test.feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="org.jboss.tools.common.all.test.feature" label="%featureName" version="3.8.3.qualifier" provider-name="%featureProvider" image="eclipse_update_120.jpg"
+<feature id="org.jboss.tools.common.all.test.feature" label="%featureName" version="3.8.100.qualifier" provider-name="%featureProvider" image="eclipse_update_120.jpg"
 	license-feature="org.jboss.tools.foundation.license.feature"
 	license-feature-version="0.0.0">
 

--- a/common/features/org.jboss.tools.common.all.test.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.all.test.feature/pom.xml
@@ -7,6 +7,7 @@
 		<version>3.8.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
-	<artifactId>org.jboss.tools.common.all.test.feature</artifactId> 
+	<artifactId>org.jboss.tools.common.all.test.feature</artifactId>
+	<version>3.8.100-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/common/features/org.jboss.tools.common.mylyn.feature/feature.xml
+++ b/common/features/org.jboss.tools.common.mylyn.feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="org.jboss.tools.common.mylyn.feature" label="%featureName" version="3.8.3.qualifier" provider-name="%providerName"
+<feature id="org.jboss.tools.common.mylyn.feature" label="%featureName" version="3.8.100.qualifier" provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">
 

--- a/common/features/org.jboss.tools.common.mylyn.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.mylyn.feature/pom.xml
@@ -8,5 +8,6 @@
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.mylyn.feature</artifactId> 
+	<version>3.8.100-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/common/plugins/org.jboss.tools.common.mylyn/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.mylyn/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Tools Mylyn Connections
 Bundle-SymbolicName: org.jboss.tools.common.mylyn;singleton:=true
-Bundle-Version: 3.8.3.qualifier
+Bundle-Version: 3.8.100.qualifier
 Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.mylyn.commons.core;bundle-version="[3.8.0,4.0.0)",

--- a/common/plugins/org.jboss.tools.common.mylyn/plugin.xml
+++ b/common/plugins/org.jboss.tools.common.mylyn/plugin.xml
@@ -7,16 +7,15 @@
 			label="Red Hat Bugzilla"
 			repositoryKind="bugzilla"
 			urlRepository="https://bugzilla.redhat.com"/>
-	    <repository
+	    <!-- JBIDE-23833 disabled <repository
            addAutomatically="true"
            anonymous="true"
            characterEncoding="UTF-8"
            label="JBoss Community"
            repositoryKind="jira"
-           urlRepository="https://issues.jboss.org">
-     </repository>
+           urlRepository="https://issues.jboss.org"/> -->
 	</extension>
- <extension
+ <!-- JBIDE-23833 disabled <extension
        point="org.eclipse.mylyn.tasks.bugs.support">
     <provider
           categoryId="org.eclipse.mylyn.tasks.bugs.openSource"
@@ -48,5 +47,5 @@
              value="JBIDE">
        </property>
     </mapping>
- </extension>
+ </extension> -->
 </plugin>

--- a/common/plugins/org.jboss.tools.common.mylyn/pom.xml
+++ b/common/plugins/org.jboss.tools.common.mylyn/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.mylyn</artifactId>
-
+	<version>3.8.100-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/common/tests/org.jboss.tools.common.mylyn.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.mylyn.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.jboss.tools.common.mylyn.test;singleton:=true
-Bundle-Version: 3.8.3.qualifier
+Bundle-Version: 3.8.100.qualifier
 Require-Bundle: org.jboss.tools.common.mylyn,
  org.junit,
  org.eclipse.mylyn.commons.core;bundle-version="3.6.0",

--- a/common/tests/org.jboss.tools.common.mylyn.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.mylyn.test/pom.xml
@@ -9,6 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.mylyn.test</artifactId>
+	<version>3.8.100-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<properties>
 		<emma.instrument.bundles>org.jboss.tools.common.mylyn</emma.instrument.bundles>

--- a/common/tests/org.jboss.tools.common.mylyn.test/src/org/jboss/tools/common/mylyn/test/RepositoryTest.java
+++ b/common/tests/org.jboss.tools.common.mylyn.test/src/org/jboss/tools/common/mylyn/test/RepositoryTest.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2011 Red Hat, Inc. 
+ * Copyright (c) 2011-2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -26,8 +26,9 @@ public class RepositoryTest extends TestCase {
 	}
 
 	// FIXME Enable this test when JIRA connector plugins are added to TP & Update site
-	public void _testJIRA() {
-		TaskRepository repo = TasksUiPlugin.getRepositoryManager().getRepository("jira", "https://issues.jboss.org");
-		assertNotNull(repo);
-	}
+	// DISABLED as part of JBIDE-23833
+	// public void _testJIRA() {
+	// 	TaskRepository repo = TasksUiPlugin.getRepositoryManager().getRepository("jira", "https://issues.jboss.org");
+	// 	assertNotNull(repo);
+	// }
 }


### PR DESCRIPTION
…oss.tools.common.mylyn, including removing test in common/tests/org.jboss.tools.common.mylyn.test/src/org/jboss/tools/common/mylyn/test/RepositoryTest.java and bumping all containing features too; also bump foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties to 4.5.0.Final

Signed-off-by: nickboldt <nboldt@redhat.com>