### PR TITLE
Primitives should not be boxed just for "String" conversion

### DIFF
--- a/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/ELReference.java
+++ b/common/plugins/org.jboss.tools.common.el.core/src/org/jboss/tools/common/el/core/ELReference.java
@@ -283,8 +283,8 @@ public class ELReference implements ITextSourceReference {
 	 */
 	public synchronized void store(Element element, Map<String,String> pathIds) {
 		element.setAttribute("path", getAlias(pathIds, path.toString())); //$NON-NLS-1$
-		element.setAttribute("offset", "" + startPosition); //$NON-NLS-1$ //$NON-NLS-2$
-		element.setAttribute("length", "" + length); //$NON-NLS-1$ //$NON-NLS-2$
+		element.setAttribute("offset", Integer.toString(startPosition)); //$NON-NLS-1$
+		element.setAttribute("length", Integer.toString(length)); //$NON-NLS-1$
 	}
 
 	public static String getAlias(Map<String, String> pathAliases, String path) {

--- a/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/ca/ELProposalProcessor.java
+++ b/common/plugins/org.jboss.tools.common.el.ui/src/org/jboss/tools/common/el/ui/ca/ELProposalProcessor.java
@@ -523,7 +523,7 @@ public abstract class ELProposalProcessor extends AbstractContentAssistProcessor
 							string = string.substring(0, string.lastIndexOf('\''));
 						
 						if (string.indexOf(']') == -1 && restOfEL.indexOf(']') == -1) // Add closing square bracket if needed
-							string += ']';
+							string += "]";
 					
 						string +=  proposalSufix;
 						resultList.add(new Proposal(string, prefix, newPrefix, offset, offset - (prefix.length() - newPrefix.length()) + string.length() - proposalSufix.length(), image,
@@ -534,7 +534,7 @@ public abstract class ELProposalProcessor extends AbstractContentAssistProcessor
 						
 						if ((string.indexOf('[') != -1 || (prefix.indexOf('[') != -1 && prefix.indexOf(']', prefix.lastIndexOf('[')) == -1)) 
 								&& string.indexOf(']') == -1 && restOfEL.indexOf(']') == -1) // Add closing square bracket if needed
-							string += ']';
+							string += "]";
 							
 						string +=  proposalSufix;
 						resultList.add(new Proposal(string, prefix, offset, offset + string.length() - proposalSufix.length(), image, 

--- a/common/plugins/org.jboss.tools.common.gef/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.gef/META-INF/MANIFEST.MF
@@ -28,5 +28,5 @@ Require-Bundle: org.jboss.tools.common,
  org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.7.100"
 Bundle-Version: 3.9.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-BundleShape: dir

--- a/common/plugins/org.jboss.tools.common.gef/src/org/jboss/tools/common/gef/GEFEditor.java
+++ b/common/plugins/org.jboss.tools.common.gef/src/org/jboss/tools/common/gef/GEFEditor.java
@@ -460,7 +460,7 @@ public class GEFEditor extends GraphicalEditor implements MouseListener,
 			return;
 		}
 		try {
-			String s = "" + fixedSise; //$NON-NLS-1$
+			String s = Integer.toString(fixedSise); //$NON-NLS-1$
 			file.setPersistentProperty(PALETTE_SIZE_KEY, s);
 		} catch (CoreException e) {
 			CommonPlugin.getPluginLog().logError(e);
@@ -492,7 +492,7 @@ public class GEFEditor extends GraphicalEditor implements MouseListener,
 			return;
 		}
 		try {
-			String s = "" + zoom; //$NON-NLS-1$
+			String s = Double.toString(zoom); //$NON-NLS-1$
 			file.setPersistentProperty(ZOOM_SIZE_KEY, s);
 		} catch (CoreException e) {
 			CommonPlugin.getPluginLog().logError(e);

--- a/common/plugins/org.jboss.tools.common.model.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.model.ui/META-INF/MANIFEST.MF
@@ -93,6 +93,6 @@ Require-Bundle: org.jboss.tools.common.model;visibility:=reexport,
  org.eclipse.jst.standard.schemas;bundle-version="1.2.0",
  org.eclipse.wst.standard.schemas
 Bundle-Version: 3.9.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: org.jboss.tools.common.model.ui.jar
 Eclipse-BundleShape: dir

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/editor/ObjectMultiPageEditor.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/editor/ObjectMultiPageEditor.java
@@ -198,7 +198,9 @@ public class ObjectMultiPageEditor extends MultiPageEditorPart implements XModel
 				saveSelectedTabForStorage();
 			} else {
 				try {
-					if(file.isAccessible()) file.setPersistentProperty(persistentTabQualifiedName, "" + selectedPageIndex); //$NON-NLS-1$
+					if(file.isAccessible()) {
+						file.setPersistentProperty(persistentTabQualifiedName, Integer.toString(selectedPageIndex)); //$NON-NLS-1$
+					}
 				} catch (CoreException e) {
 					ModelUIPlugin.getPluginLog().logError(e);
 				}		
@@ -212,7 +214,7 @@ public class ObjectMultiPageEditor extends MultiPageEditorPart implements XModel
 		String path = object.getPath();
 		QualifiedName qn = new QualifiedName("", "Selected_tab_" + path); //$NON-NLS-1$ //$NON-NLS-2$
 		try {
-			p.setPersistentProperty(qn, "" + selectedPageIndex); //$NON-NLS-1$
+			p.setPersistentProperty(qn, Integer.toString(selectedPageIndex)); //$NON-NLS-1$
 		} catch (CoreException e) {
 			//ignore
 		}

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/attribute/editor/CheckListFieldEditor.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/attribute/editor/CheckListFieldEditor.java
@@ -137,7 +137,7 @@ public class CheckListFieldEditor extends ExtendedFieldEditor implements IFieldE
 //			Object input = propertyEditor.getInput();
 			setErrorProvider((IAttributeErrorProvider)propertyEditor.getAdapter(IAttributeErrorProvider.class));
 			if(propertyEditor.getInput() instanceof CheckListAdapter) {
-				separator = "" + ((CheckListAdapter)propertyEditor.getInput()).getSeparator();
+				separator = Character.toString(((CheckListAdapter)propertyEditor.getInput()).getSeparator());
 			}
 		}
 		init();

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/attribute/editor/SliderFieldEditor.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/attribute/editor/SliderFieldEditor.java
@@ -219,7 +219,7 @@ public class SliderFieldEditor extends ExtendedFieldEditor implements
 		 * Initialize slider presentation
 		 */
 		slider.setSelection(intValue);
-		String weightsString = "" + (intValue /10)+"% / " + ((100 - intValue/10)) + "%";  //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		String weightsString = Integer.toString(intValue /10)+"% / " + (100 - intValue/10) + "%";  //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		slider.setToolTipText(weightsString);
 		sliderLabel.setText(weightsString);
 		
@@ -253,7 +253,7 @@ public class SliderFieldEditor extends ExtendedFieldEditor implements
 				/*
 				 * Show value in percents.
 				 */
-				String weightsString = "" + (intValue / 10) + "% / " //$NON-NLS-1$ //$NON-NLS-2$
+				String weightsString = Integer.toString(intValue / 10) + "% / " //$NON-NLS-1$ //$NON-NLS-2$
 						+ ((100 - intValue / 10)) + "%"; //$NON-NLS-1$
 				slider.setToolTipText(weightsString);
 				if (null != sliderLabel) {

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/attribute/editor/SliderFieldEditor2.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/attribute/editor/SliderFieldEditor2.java
@@ -219,7 +219,7 @@ public class SliderFieldEditor2 extends ExtendedFieldEditor implements
 		 * Initialize slider presentation
 		 */
 		slider.setSelection(intValue);
-		String weightsString = "" + (intValue /10) + "%";  //$NON-NLS-1$ //$NON-NLS-2$
+		String weightsString = Integer.toString(intValue /10) + "%";  //$NON-NLS-1$ //$NON-NLS-2$
 		slider.setToolTipText(weightsString);
 		sliderLabel.setText(weightsString);
 		
@@ -253,7 +253,7 @@ public class SliderFieldEditor2 extends ExtendedFieldEditor implements
 				/*
 				 * Show value in percents.
 				 */
-				String weightsString = "" + (intValue / 10) + "%"; //$NON-NLS-1$ //$NON-NLS-2$
+				String weightsString = Integer.toString(intValue / 10) + "%"; //$NON-NLS-1$ //$NON-NLS-2$
 				slider.setToolTipText(weightsString);
 				if (null != sliderLabel) {
 					sliderLabel.setText(weightsString);

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/forms/ExpandableForm.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/forms/ExpandableForm.java
@@ -163,7 +163,7 @@ public class ExpandableForm extends DefaultForm {
 	}
 
 	public void store(IMemento memento) {
-		memento.putString(COLLAPSED_ID, ""+isCollapsed()); //$NON-NLS-1$
+		memento.putString(COLLAPSED_ID, Boolean.toString(isCollapsed())); //$NON-NLS-1$
 	}
 
 }

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/forms/MementoDOM.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/forms/MementoDOM.java
@@ -138,14 +138,14 @@ public class MementoDOM implements IMemento {
 	 * @see org.eclipse.ui.IMemento#putFloat(java.lang.String, float)
 	 */
 	public void putFloat(String key, float value) {
-		element.setAttribute(key, ""+value); //$NON-NLS-1$
+		element.setAttribute(key, Float.toString(value)); //$NON-NLS-1$
 	}
 
 	/* (non-Javadoc)
 	 * @see org.eclipse.ui.IMemento#putInteger(java.lang.String, int)
 	 */
 	public void putInteger(String key, int value) {
-		element.setAttribute(key, ""+value); //$NON-NLS-1$
+		element.setAttribute(key, Integer.toString(value)); //$NON-NLS-1$
 	}
 
 	/* (non-Javadoc)

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/image/XModelObjectImageDescriptor.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/image/XModelObjectImageDescriptor.java
@@ -33,7 +33,7 @@ public class XModelObjectImageDescriptor extends ImageDescriptor {
 	public Image createImage(boolean returnMissingImageOnError, Device device) {
 		int code = xicon.getIconHash();
 		if (code == 0) return null;
-		String key = "" + code; //$NON-NLS-1$
+		String key = Integer.toString(code); //$NON-NLS-1$
 		Image img = (Image)imageCache.get(key);
 		if (img != null) return img;
 		img = xicon.getEclipseImage();

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/navigator/LabelDecoratorImpl.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/navigator/LabelDecoratorImpl.java
@@ -80,7 +80,7 @@ public class LabelDecoratorImpl implements ILabelDecorator {
 
 	private void registerImage(Image i) {
 		ImageRegistry registry = ModelUIPlugin.getDefault().getImageRegistry();
-		String key = "" + Math.random(); //We retrieve created images by maps, let use unique random key for registry.
+		String key = Double.toString(Math.random()); //We retrieve created images by maps, let use unique random key for registry.
 		synchronized(registry) {
 			registry.remove(key); //Just in case, to be on the safe side.
 			registry.put(key, i);

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/templates/configuration/MetaClassTemplateHelper.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/templates/configuration/MetaClassTemplateHelper.java
@@ -62,7 +62,7 @@ public class MetaClassTemplateHelper {
 	public void setProjectOverrideTemplates(boolean b) {
 		QualifiedName qn = new QualifiedName(ModelUIPlugin.ID_PLUGIN, ModelUIPlugin.PROJECT_OVERRIDE); 
 		try {
-			ResourcesPlugin.getWorkspace().getRoot().setPersistentProperty(qn, "" + b); //$NON-NLS-1$
+			ResourcesPlugin.getWorkspace().getRoot().setPersistentProperty(qn, Boolean.toString(b)); //$NON-NLS-1$
 		} catch (CoreException e) {
 			ModelUIPlugin.getPluginLog().logError(e);
 		}

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/templates/preferences/TemplateComponent.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/templates/preferences/TemplateComponent.java
@@ -58,7 +58,7 @@ public class TemplateComponent {
         // checkbox
         if(!isGlobal) {  //.getString CHECKBOX_LABEL
         	allowOverrideEditor.setLabelText(Messages.CHECKBOX_LABEL);
-        	allowOverrideAdapter.setValue("" + MetaClassTemplateHelper.instance. isProjectOverrideTemplates()); //$NON-NLS-1$
+        	allowOverrideAdapter.setValue(Boolean.toString(MetaClassTemplateHelper.instance. isProjectOverrideTemplates())); //$NON-NLS-1$
             control = getControls(composite, allowOverrideEditor);
             control[0].dispose(); // dispose empty label
             gd = new GridData(GridData.FILL_HORIZONTAL);

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/texteditors/dnd/TextEditorDrop.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/texteditors/dnd/TextEditorDrop.java
@@ -62,7 +62,7 @@ public class TextEditorDrop implements IControlDragDropProvider, IControlDropLis
 		String text = provider.getSourceViewer().getDocument().get();
 		p.setProperty("text", text); //$NON-NLS-1$
 		int pos = getPosition(x, y);
-		p.setProperty("pos", "" + pos); //$NON-NLS-1$ //$NON-NLS-2$
+		p.setProperty("pos", Integer.toString(pos)); //$NON-NLS-1$ //$NON-NLS-2$
 		p.put("viewer", provider.getSourceViewer()); //$NON-NLS-1$
 		if(provider instanceof TextEditorDropProvider2) {
 			String context = ((TextEditorDropProvider2)provider).getContext(pos);

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/texteditors/preferences/ReplaceTabsAdapter.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/texteditors/preferences/ReplaceTabsAdapter.java
@@ -12,7 +12,6 @@ package org.jboss.tools.common.model.ui.texteditors.preferences;
 
 import org.jboss.tools.common.meta.constraint.*;
 import org.jboss.tools.common.model.XModelObject;
-import org.jboss.tools.common.model.ui.ModelUIPlugin;
 import org.jboss.tools.common.text.xml.ui.xpl.BasePreferenceConstants;
 
 public class ReplaceTabsAdapter extends XAdapter {
@@ -22,7 +21,7 @@ public class ReplaceTabsAdapter extends XAdapter {
 
 	public String getProperty(XProperty object) {
 		if(EditorsPreferencesPage.store == null) return "false"; //$NON-NLS-1$
-		return "" + EditorsPreferencesPage.store.getBoolean(PROPERTY); //$NON-NLS-1$
+		return Boolean.toString(EditorsPreferencesPage.store.getBoolean(PROPERTY)); //$NON-NLS-1$
 	}
 
 	public void setProperty(XProperty object, String value) {

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/texteditors/preferences/TabWidthAdapter.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/model/ui/texteditors/preferences/TabWidthAdapter.java
@@ -24,7 +24,7 @@ public class TabWidthAdapter extends XAdapter {
 		if(EditorsPreferencesPage.store == null) return "4"; //$NON-NLS-1$
 		int i = EditorsPreferencesPage.store.getInt(PROPERTY);
 		if(i == 0) EditorsPreferencesPage.store.setDefault(PROPERTY, "4"); //$NON-NLS-1$
-		return "" + EditorsPreferencesPage.store.getInt(PROPERTY); //$NON-NLS-1$
+		return Integer.toString(EditorsPreferencesPage.store.getInt(PROPERTY)); //$NON-NLS-1$
 	}
 	public void setProperty(XProperty object, String value) {
 		XModelObject o = (XModelObject)object;

--- a/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/propertieseditor/PropertiesEditor.java
+++ b/common/plugins/org.jboss.tools.common.model.ui/src/org/jboss/tools/common/propertieseditor/PropertiesEditor.java
@@ -438,11 +438,11 @@ public class PropertiesEditor extends XChildrenEditor implements ITextEditor, IT
 	void savePreferences(IFile f) {
 		if(f == null || !f.exists()) return;
 		try {
-			f.setPersistentProperty(filterOpenedId, "" + filterOpened); //$NON-NLS-1$
+			f.setPersistentProperty(filterOpenedId, Boolean.toString(filterOpened)); //$NON-NLS-1$
 			f.setPersistentProperty(nameFilterId, pHelper.nameFilter);
 			f.setPersistentProperty(valueFilterId, "" + pHelper.valueFilter); //$NON-NLS-1$
-			f.setPersistentProperty(isFilterExpressionId, "" + isFilterExpression); //$NON-NLS-1$
-			f.setPersistentProperty(isCaseSensitiveId, "" + isCaseSensitive); //$NON-NLS-1$
+			f.setPersistentProperty(isFilterExpressionId, Boolean.toString(isFilterExpression)); //$NON-NLS-1$
+			f.setPersistentProperty(isCaseSensitiveId, Boolean.toString(isCaseSensitive)); //$NON-NLS-1$
 		} catch (CoreException e) {
 			//ignore
 		}

--- a/common/plugins/org.jboss.tools.common.model/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.model/META-INF/MANIFEST.MF
@@ -89,6 +89,6 @@ Require-Bundle: org.jboss.tools.common;visibility:=reexport,
  org.eclipse.core.filesystem,
  org.jboss.tools.common.model.ui.capabilities;bundle-version="3.6.0"
 Bundle-Version: 3.9.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: org.jboss.tools.common.model.jar
 Eclipse-BundleShape: dir

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/meta/action/impl/handlers/AddAttributeToAnyElementSupport.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/meta/action/impl/handlers/AddAttributeToAnyElementSupport.java
@@ -66,7 +66,9 @@ public class AddAttributeToAnyElementSupport extends SpecialWizardSupport {
 		String as = ""; //$NON-NLS-1$
 		if(!edit) {
 			as = getTarget().getAttributeValue(ATTRIBUTES);
-			if(as.length() > 0) as += AnyElementObjectImpl.SEPARATOR;
+			if(as.length() > 0) {
+				as += Character.toString(AnyElementObjectImpl.SEPARATOR);
+			}
 			as += name + "=" + value; //$NON-NLS-1$
 		} else {
 			String[][] attrs = getAttributes();

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/meta/action/impl/handlers/DefaultCreateHandler.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/meta/action/impl/handlers/DefaultCreateHandler.java
@@ -196,7 +196,7 @@ public class DefaultCreateHandler extends AbstractHandler {
 			int k = 1;
 			String pp = child.getPathPart();
 			while(parent.getChildByPath(pp) != null) {
-				child.setAttributeValue(XModelObjectLoaderUtil.ATTR_ID_NAME, "" + k); //$NON-NLS-1$
+				child.setAttributeValue(XModelObjectLoaderUtil.ATTR_ID_NAME, Integer.toString(k)); //$NON-NLS-1$
 				String ppn = child.getPathPart();
 				if(ppn.equals(pp)) throw new RuntimeException(ModelMessages.OBJECT_ADDING_FAILURE);
 				pp = ppn;

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/meta/impl/documentation/DocumentGenerator.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/meta/impl/documentation/DocumentGenerator.java
@@ -189,7 +189,7 @@ public class DocumentGenerator {
     void createHeaderCell(Element e, String name, int width) {
         Element td = XMLUtil.createElement(e, "td"); //$NON-NLS-1$
         td.setAttribute("class", XModelObjectConstants.ATTR_NAME); //$NON-NLS-1$
-        if(width > 0) td.setAttribute("width", "" + width); //$NON-NLS-1$ //$NON-NLS-2$
+        if(width > 0) td.setAttribute("width", Integer.toString(width)); //$NON-NLS-1$ //$NON-NLS-2$
         XMLUtil2.createText(td, name);
     }
     void createValueCell(Element e, String value) {
@@ -331,7 +331,7 @@ class XMLUtil2 {
 
     public static void hr(Element e, int length) {
         Element h = XMLUtil.createElement(e, "hr"); //$NON-NLS-1$
-        h.setAttribute("width", "" + length); //$NON-NLS-1$ //$NON-NLS-2$
+        h.setAttribute("width", Integer.toString(length)); //$NON-NLS-1$ //$NON-NLS-2$
         h.setAttribute("align", "left"); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
@@ -374,19 +374,19 @@ class XMLUtil2 {
 }
 
 class ContentGenerator {
-    private HashMap<String,XModelObject> list = new HashMap<String,XModelObject>();
+    private HashMap<String,XModelObject> list = new HashMap<>();
 
     public void generate(Element element, XModelObject o) {
         processGroup(o);
         XMLUtil2.createSubTitle(element, "Entities");
-        String[] keys = (String[])list.keySet().toArray(new String[0]);
+        String[] keys = list.keySet().toArray(new String[0]);
         Arrays.sort(keys);
         char c = ' ';
         for (int i = 0; i < keys.length; i++) {
             char cx = keys[i].charAt(0);
             if(cx != c) {
                 c = cx;
-                XMLUtil2.createSubTitle(element, "" + c); //$NON-NLS-1$
+                XMLUtil2.createSubTitle(element, Character.toString(c)); //$NON-NLS-1$
             }
             XMLUtil2.createEntityReference(element, keys[i]);
         }

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/AbstractExtendedXMLFileImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/AbstractExtendedXMLFileImpl.java
@@ -262,7 +262,7 @@ public class AbstractExtendedXMLFileImpl extends AbstractXMLFileImpl {
 			if(changed && ots == getTimeStamp()) {
 				changeTimeStamp();
 			}
-			set("actualBodyTimeStamp", "" + getTimeStamp()); //$NON-NLS-1$ //$NON-NLS-2$
+			set("actualBodyTimeStamp", Long.toString(getTimeStamp())); //$NON-NLS-1$ //$NON-NLS-2$
 			if(errors1) m.fireStructureChanged(this);
         	if(!isOverlapped) {
         		check();
@@ -284,9 +284,9 @@ public class AbstractExtendedXMLFileImpl extends AbstractXMLFileImpl {
     }
     
     protected void safeChangeTimeStamp() {
-    	boolean b = ("" + getTimeStamp()).equals(get("actualBodyTimeStamp")); //$NON-NLS-1$ //$NON-NLS-2$
+    	boolean b = Long.toString(getTimeStamp()).equals(get("actualBodyTimeStamp")); //$NON-NLS-1$ //$NON-NLS-2$
     	changeTimeStamp();
-    	if(b) set("actualBodyTimeStamp", "" + getTimeStamp()); //$NON-NLS-1$ //$NON-NLS-2$
+    	if(b) set("actualBodyTimeStamp", Long.toString(getTimeStamp())); //$NON-NLS-1$ //$NON-NLS-2$
     }
     protected void mergeAll(XModelObject f, boolean update) throws XModelException {
    		merge(f, !update);

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/AbstractXMLFileImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/AbstractXMLFileImpl.java
@@ -81,7 +81,7 @@ public class AbstractXMLFileImpl extends RecognizedFileImpl {
 			try {
 				if(q >= 0 && ln1.length() > 0) {
 					iln = Integer.parseInt(ln1);
-					ln1 = "" + (iln - 1); //$NON-NLS-1$
+					ln1 = Integer.toString(iln - 1); //$NON-NLS-1$
 				}
 			} catch (NumberFormatException e) {
 //				ignore, some errors found by entity resolver do not have coordinates

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/FileSystemsImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/FileSystemsImpl.java
@@ -141,7 +141,7 @@ public class FileSystemsImpl extends OrderedObjectImpl implements IResourceChang
                 File f = new File(path);
                 path = f.getCanonicalPath().replace('\\', '/');
                 path = FilePathHelper.toPathPath(path);
-                if (path.charAt(path.length()-1) != '/') path += '/';
+                if (path.charAt(path.length()-1) != '/') path += "/";
                 paths[i] = path;
                 if(cs[i].getModelEntity().getName().equals(XModelObjectConstants.ENT_FILE_SYSTEM_FOLDER)) {
                 	folders.add(i);

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/HiddenSystemsHandler.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/HiddenSystemsHandler.java
@@ -35,7 +35,7 @@ public class HiddenSystemsHandler extends AbstractHandler {
             String name = fs[i].getAttributeValue(XModelObjectConstants.ATTR_NAME);
             Properties fsp = XModelObjectUtil.toProperties(fs[i]);
             String hidden = "" + fsp.getProperty("hidden", XModelObjectConstants.NO); //$NON-NLS-1$ //$NON-NLS-2$
-            String jar = "" + "FileSystemJar".equals(fs[i].getModelEntity().getName()); //$NON-NLS-1$ //$NON-NLS-2$
+            String jar = Boolean.toString("FileSystemJar".equals(fs[i].getModelEntity().getName())); //$NON-NLS-1$ //$NON-NLS-2$
             vs[i] = new String[]{name, hidden, jar};
         }
         if(p == null) p = new Properties();

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/SimpleFileImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/filesystems/impl/SimpleFileImpl.java
@@ -35,13 +35,13 @@ public class SimpleFileImpl extends AbstractExtendedXMLFileImpl {
     public String getBody() {
 		if(isIncorrect()) return get(ATTR_NAME_INCORRECT_BODY);
 		String abts = get("actualBodyTimeStamp"); //$NON-NLS-1$
-		if(abts != null && (abts.equals("0") || abts.equals("" + getTimeStamp()))) { //$NON-NLS-1$ //$NON-NLS-2$
+		if(abts != null && ("0".equals(abts) || abts.equals(Long.toString(getTimeStamp())))) { //$NON-NLS-1$ //$NON-NLS-2$
 			return get(ATTR_NAME_CORRECT_BODY);
 		}
 		if(loader == null) loader = (SerializingLoader)XModelObjectLoaderUtil.getObjectLoader(this);
 		String body = loader.serializeObject(this);
 		set(ATTR_NAME_CORRECT_BODY, body);
-		set("actualBodyTimeStamp", "" + getTimeStamp()); //$NON-NLS-1$ //$NON-NLS-2$
+		set("actualBodyTimeStamp", Long.toString(getTimeStamp())); //$NON-NLS-1$ //$NON-NLS-2$
 		return body;
     }
 

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/icons/impl/XModelObjectIcon.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/icons/impl/XModelObjectIcon.java
@@ -44,7 +44,7 @@ public class XModelObjectIcon {
 
     public Image getIcon1(String[] types) {
         if(object == null) return null;
-        String code = "" + getIconHash(types); //$NON-NLS-1$
+        String code = Integer.toString(getIconHash(types)); //$NON-NLS-1$
         ImageRegistry registry = ModelPlugin.getDefault().getImageRegistry();
         Image ii = null;
         synchronized (registry) {
@@ -84,7 +84,7 @@ public class XModelObjectIcon {
     
 	public Image getEclipseImage0(String[] types) {
 		if(object == null) return null;
-		String code = "" + getIconHash(types); //$NON-NLS-1$
+		String code = Integer.toString(getIconHash(types)); //$NON-NLS-1$
 		ImageRegistry registry = ModelPlugin.getDefault().getImageRegistry();
 		Image iie = null;
 		synchronized(registry) {

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/impl/AnyElementObjectImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/impl/AnyElementObjectImpl.java
@@ -29,7 +29,7 @@ public class AnyElementObjectImpl extends OrderedObjectImpl {
 	
 	public String[][] getAttributes() {
 		String attrs = getAttributeValue("attributes"); //$NON-NLS-1$
-		StringTokenizer st = new StringTokenizer(attrs, "" + SEPARATOR); //$NON-NLS-1$
+		StringTokenizer st = new StringTokenizer(attrs, Character.toString(SEPARATOR)); //$NON-NLS-1$
 		int length = st.countTokens();
 		String[][] as = new String[length][2];
 		for (int i = 0; i < length; i++) {

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/impl/RegularObjectImpl.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/impl/RegularObjectImpl.java
@@ -130,7 +130,7 @@ public class RegularObjectImpl extends XModelObjectImpl implements XOrderedObjec
         	if(getModelEntity().getAttribute(XModelObjectLoaderUtil.ATTR_ID_NAME) != null) {
         		int k = 1;
         		while(c != null) {
-        			super.set(XModelObjectLoaderUtil.ATTR_ID_NAME, "" + k); //$NON-NLS-1$
+        			super.set(XModelObjectLoaderUtil.ATTR_ID_NAME, Integer.toString(k)); //$NON-NLS-1$
         			npp = getPathPart();
         			c = p.children.change(this, opp, npp);
         			k++;
@@ -139,7 +139,7 @@ public class RegularObjectImpl extends XModelObjectImpl implements XOrderedObjec
         	} else if(hasIdAttr()) {
         		int k = 1;
         		while(c != null) {
-        			super.set(XModelObjectImpl.DUPLICATE, "" + k); //$NON-NLS-1$
+        			super.set(XModelObjectImpl.DUPLICATE, Integer.toString(k)); //$NON-NLS-1$
         			npp = getPathPart();
         			if(k == 1 && npp.indexOf(XModelObjectImpl.DUPLICATE) < 0) {
         				elementExists(c, name, value);

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/loaders/impl/PropertiesLoader.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/loaders/impl/PropertiesLoader.java
@@ -183,7 +183,7 @@ public class PropertiesLoader implements XObjectLoader {
 			p.setProperty("dirtyname", dirtyName); //$NON-NLS-1$
             p.setProperty("value", value); //$NON-NLS-1$
             
-            p.setProperty("name-value-separator", i == s.length() ? " " : "" + s.charAt(i)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            p.setProperty("name-value-separator", i == s.length() ? " " : Character.toString(s.charAt(i))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             p.setProperty("comments", comments); //$NON-NLS-1$
             p.setProperty("separator", "#"); //obsolete //$NON-NLS-1$ //$NON-NLS-2$
             p.setProperty("line-end", ""); //$NON-NLS-1$ //$NON-NLS-2$
@@ -193,11 +193,11 @@ public class PropertiesLoader implements XObjectLoader {
             	if(q != null) {
             		int k = 1;
             		while(true) {
-            			c.set(XModelObjectImpl.DUPLICATE, "" + k);
+            			c.set(XModelObjectImpl.DUPLICATE, Integer.toString(k));
             			if(object.getChildByPath(c.getPathPart()) == null) break;
             			k++;
             		}
-            		q.set(XModelObjectImpl.DUPLICATE, "" + k);
+            		q.set(XModelObjectImpl.DUPLICATE, Integer.toString(k));
             		q.setAttributeValue("value", convertDirtyValue(q.getAttributeValue("dirtyvalue"))); 
             		c.set(XModelObjectImpl.DUPLICATE, "");
 
@@ -549,11 +549,11 @@ class PropertyValueParser {
 						tokens.add(new PropertyValueToken(value.substring(offset - 2, offset + 4), "" + (char)code));
 						offset += 4;
 					} else {
-						tokens.add(new PropertyValueToken(value.substring(offset - 1, offset + 1), "" + ch));
+						tokens.add(new PropertyValueToken(value.substring(offset - 1, offset + 1), Character.toString(ch)));
 						offset++;
 					}
 				} else {
-					tokens.add(new PropertyValueToken(value.substring(offset, offset + 1), "" + ch));
+					tokens.add(new PropertyValueToken(value.substring(offset, offset + 1), Character.toString(ch)));
 					offset++;
 				}
 			}

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/loaders/impl/SimpleWebFileLoader.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/loaders/impl/SimpleWebFileLoader.java
@@ -68,13 +68,13 @@ public class SimpleWebFileLoader implements SerializingLoader, XModelObjectConst
         setEncoding(object, body);
 		loadPublicId(object, doc);
 
-		object.set("actualBodyTimeStamp", "" + object.getTimeStamp()); //$NON-NLS-1$ //$NON-NLS-2$
+		object.set("actualBodyTimeStamp", Long.toString(object.getTimeStamp())); //$NON-NLS-1$ //$NON-NLS-2$
 		
 		((AbstractXMLFileImpl)object).setLoaderError(loadingError);
 		if(!((AbstractXMLFileImpl)object).isIncorrect() && loadingError != null) {
 			object.setAttributeValue(ATTR_NAME_IS_INCORRECT, YES);
 			object.setAttributeValue(ATTR_NAME_INCORRECT_BODY, body);
-			object.set("actualBodyTimeStamp", "" + object.getTimeStamp()); //$NON-NLS-1$ //$NON-NLS-2$
+			object.set("actualBodyTimeStamp", Long.toString(object.getTimeStamp())); //$NON-NLS-1$ //$NON-NLS-2$
 		}
     }
     

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/project/ext/impl/ValueInfo.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/project/ext/impl/ValueInfo.java
@@ -140,8 +140,8 @@ public class ValueInfo implements IValueInfo {
 	public Element toXML(Element parent, Properties context) {
 		Element element = XMLUtilities.createElement(parent, XMLStoreConstants.TAG_VALUE_INFO);
 		if(value != null) element.setAttribute(XMLStoreConstants.ATTR_VALUE, value);
-		if(valueStartPosition != 0) element.setAttribute(ATTR_START, "" + valueStartPosition); //$NON-NLS-1$
-		if(valueLength != 0) element.setAttribute(ATTR_LENGTH, "" + valueLength); //$NON-NLS-1$
+		if(valueStartPosition != 0) element.setAttribute(ATTR_START, Integer.toString(valueStartPosition)); //$NON-NLS-1$
+		if(valueLength != 0) element.setAttribute(ATTR_LENGTH, Integer.toString(valueLength)); //$NON-NLS-1$
 		return element;
 	}
 	

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/util/FindObjectHelper.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/util/FindObjectHelper.java
@@ -74,7 +74,7 @@ public class FindObjectHelper implements SpecialWizard {
         XModelObject o = findRef();
         if(o == null) o = findJava();
         if(o != null) {
-            o.set("_error_line_", "" + line); //$NON-NLS-1$ //$NON-NLS-2$
+            o.set("_error_line_", Integer.toString(line)); //$NON-NLS-1$ //$NON-NLS-2$
             select.setObject(o);
             select.execute();
             o.set("_error_line_", ""); //$NON-NLS-1$ //$NON-NLS-2$

--- a/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/util/XModelObjectLoaderUtil.java
+++ b/common/plugins/org.jboss.tools.common.model/src/org/jboss/tools/common/model/util/XModelObjectLoaderUtil.java
@@ -323,7 +323,7 @@ public class XModelObjectLoaderUtil {
         			int k = 1;
         			String pp = co.getPathPart();
         			while(o.getChildByPath(pp) != null) {
-        				co.setAttributeValue(ATTR_ID_NAME, "" + k); //$NON-NLS-1$
+        				co.setAttributeValue(ATTR_ID_NAME, Integer.toString(k)); //$NON-NLS-1$
         				String ppn = co.getPathPart();
         				if(ppn.equals(pp)) break;
         				pp = ppn;
@@ -341,7 +341,7 @@ public class XModelObjectLoaderUtil {
         			int k = 1;
         			String pp = co.getPathPart();
         			while(o.getChildByPath(pp) != null) {
-        				co.set(XModelObjectImpl.DUPLICATE, "" + k); //$NON-NLS-1$
+        				co.set(XModelObjectImpl.DUPLICATE, Integer.toString(k)); //$NON-NLS-1$
         				String ppn = co.getPathPart();
         				if(ppn.equals(pp)) break;
         				pp = ppn;

--- a/common/plugins/org.jboss.tools.common.text.xml/src/org/jboss/tools/common/text/xml/XMLTextViewerConfiguration.java
+++ b/common/plugins/org.jboss.tools.common.text.xml/src/org/jboss/tools/common/text/xml/XMLTextViewerConfiguration.java
@@ -94,7 +94,7 @@ public class XMLTextViewerConfiguration extends StructuredTextViewerConfiguratio
 						String chars = new String(superAutoActivationCharacters);
 						for (char ch : PROPOSAL_AUTO_ACTIVATION_CHARS) {
 							if (chars.indexOf(ch) == -1) {
-								chars += ch;
+								chars += Character.toString(ch);
 							}
 						}
 						return chars.toCharArray();

--- a/common/plugins/org.jboss.tools.common.verification.ui/src/org/jboss/tools/common/verification/ui/vrules/wizard/runtime/VerifyWizardView.java
+++ b/common/plugins/org.jboss.tools.common.verification.ui/src/org/jboss/tools/common/verification/ui/vrules/wizard/runtime/VerifyWizardView.java
@@ -254,7 +254,7 @@ public class VerifyWizardView extends AbstractQueryWizardView {
 			new Runnable() {
 				public void run() {
 					ServiceDialog d = model.getService();
-					d.showDialog(VerificationUIMessages.WARNING, NLS.bind(VerificationUIMessages.LIMIT_OF_REPORTED_ERRORS_IS_REACHED, ""+getErrorCountLimit()), new String[]{VerificationUIMessages.OK}, null, ServiceDialog.WARNING); //$NON-NLS-1$
+					d.showDialog(VerificationUIMessages.WARNING, NLS.bind(VerificationUIMessages.LIMIT_OF_REPORTED_ERRORS_IS_REACHED, Integer.toString(getErrorCountLimit())), new String[]{VerificationUIMessages.OK}, null, ServiceDialog.WARNING); //$NON-NLS-1$
 					limitLock = false;
 					task.stop();
 				}

--- a/common/plugins/org.jboss.tools.common.verification/src/org/jboss/tools/common/verification/vrules/model/VResultModel.java
+++ b/common/plugins/org.jboss.tools.common.verification/src/org/jboss/tools/common/verification/vrules/model/VResultModel.java
@@ -33,7 +33,7 @@ public class VResultModel extends XModelObjectImpl {
     public void setResult(VResult result) {
         this.result = result;
         setAttributeValue("message", result.getMessage()); //$NON-NLS-1$
-        setAttributeValue("significance", ""+result.getSignificance()); //$NON-NLS-1$ //$NON-NLS-2$
+        setAttributeValue("significance", Integer.toString(result.getSignificance())); //$NON-NLS-1$ //$NON-NLS-2$
         setAttributeValue("source object", result.getSourceObject().getPath()); //$NON-NLS-1$
         setAttributeValue("source position", ""+result.getSourcePosition()); //$NON-NLS-1$ //$NON-NLS-2$
         setAttributeValue("target object", result.getTargetObject().getPath()); //$NON-NLS-1$
@@ -42,7 +42,7 @@ public class VResultModel extends XModelObjectImpl {
     }
     
     public String getPathPart() {
-        return ""+System.identityHashCode(this); //$NON-NLS-1$
+        return Integer.toString(System.identityHashCode(this)); //$NON-NLS-1$
     }
 
     public String getPresentationString() {

--- a/runtime/plugins/org.jboss.tools.runtime.ui/src/org/jboss/tools/runtime/ui/internal/wizard/FinalizeRuntimeDownloadFragment.java
+++ b/runtime/plugins/org.jboss.tools.runtime.ui/src/org/jboss/tools/runtime/ui/internal/wizard/FinalizeRuntimeDownloadFragment.java
@@ -293,7 +293,7 @@ public class FinalizeRuntimeDownloadFragment extends WizardFragment {
 			
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				delete = new Boolean(deleteOnExit.getSelection()).toString();
+				delete = Boolean.toString(deleteOnExit.getSelection());
 			}
 		});
 		

--- a/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/event/UsageEventType.java
+++ b/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/event/UsageEventType.java
@@ -197,7 +197,7 @@ public class UsageEventType {
 	public static String getVersion(Plugin plugin) {
 		Assert.isLegal(plugin!=null, "Plugin may not be null");
 		Version version = plugin.getBundle().getVersion();
-		return "" + version.getMajor() + "." + version.getMinor() + "." + version.getMicro();
+		return version.getMajor() + "." + version.getMinor() + "." + version.getMicro();
 	}
 
 	@Override

--- a/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/event/EventRegister.java
+++ b/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/event/EventRegister.java
@@ -320,9 +320,9 @@ public class EventRegister {
 						pr.put(EVENT_TYPE_VALUE_DESCRIPTION, type.getValueDescription());
 					}
 				}
-				pr.put(EVENT_TYPE_DATE, "" + properties.date);
-				pr.put(EVENT_TYPE_COUNT, "" + properties.count);
-				pr.put(EVENT_TYPE_VALUE_SUM, "" + properties.value);
+				pr.put(EVENT_TYPE_DATE, Long.toString(properties.date));
+				pr.put(EVENT_TYPE_COUNT, Integer.toString(properties.count));
+				pr.put(EVENT_TYPE_VALUE_SUM, Integer.toString(properties.value));
 				pr.put(EVENT_TYPE_COUNT_EVENT_LABEL, properties.countEventLabel);
 				pr.store(writer, null);
 				return true;


### PR DESCRIPTION
it has performance impact. Integer.toString, Character.toSring and so on
should be used.


Signed-off-by: Aurelien Pupier <apupier@redhat.com>

see https://sonarcloud.io/project/issues?id=org.jboss.tools%3Abase&open=AVpcTdT7GqtTGnUlDxWG&resolved=false&rules=squid%3AS2131&tags=performance&types=BUG