### PR TITLE
JBIDE-24968 use download-maven-plugin:1.3.0...

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
@@ -50,7 +50,8 @@
 			</plugin>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
+				<version>1.3.0</version>
 				<executions>
 					<execution>
 						<id>wget-ide-config-properties</id>
@@ -59,6 +60,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
+							<skip>false</skip>
 							<url>http://download.jboss.org/jbosstools/configuration/ide-config.properties</url>
 							<skipCache>true</skipCache>
 							<outputDirectory>${local.config.properties.dir}</outputDirectory>


### PR DESCRIPTION
JBIDE-24968 use download-maven-plugin:1.3.0 instead of old maven-download-plugin:1.1, and set skip=false

Signed-off-by: nickboldt <nboldt@redhat.com>