### PR TITLE
JBIDE-25106 - improve robustness for untar

### DIFF
--- a/runtime/plugins/org.jboss.tools.runtime.core/src/org/jboss/tools/runtime/core/extract/internal/UntarUtility.java
+++ b/runtime/plugins/org.jboss.tools.runtime.core/src/org/jboss/tools/runtime/core/extract/internal/UntarUtility.java
@@ -84,14 +84,21 @@ public class UntarUtility implements IExtractUtility {
 			}
 			
 			if (name != null && name.length() > 0) {
+				File entryFile = path.append(name).toFile();
 				if (entry.getFileType() == TarEntry.DIRECTORY)
-					path.append(name).toFile().mkdirs();
+					entryFile.mkdirs();
 				else {
 					File dir = path.append(name).removeLastSegments(1).toFile();
 					if (!dir.exists())
 						dir.mkdirs();
 					
-					FileOutputStream fout = new FileOutputStream(path.append(name).toFile());
+					if (entryFile.isDirectory()) {
+						RuntimeCoreActivator.pluginLog().logError(NLS.bind("Invalid archive, {0} is a directory and a file entry at the same time.", entryFile.getPath())); //$NON-NLS-1$
+						entry = zin.getNextEntry();
+						continue;
+					}
+					
+					FileOutputStream fout = new FileOutputStream(entryFile);
 					copyWithSize(zin, fout, progress.newChild(1), (int)entry.getSize());
 					fout.close();
 					if (fileCnt <= 0)

--- a/runtime/tests/org.jboss.tools.runtime.test/META-INF/MANIFEST.MF
+++ b/runtime/tests/org.jboss.tools.runtime.test/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.jboss.tools.runtime.core,
  org.jboss.tools.tests,
  org.jboss.tools.common,
- org.eclipse.core.jobs
+ org.eclipse.core.jobs,
+ org.eclipse.ui.ide
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %BundleVendor

--- a/runtime/tests/org.jboss.tools.runtime.test/src/org/jboss/tools/runtime/test/RuntimeDetectionAllTests.java
+++ b/runtime/tests/org.jboss.tools.runtime.test/src/org/jboss/tools/runtime/test/RuntimeDetectionAllTests.java
@@ -11,6 +11,7 @@
 package org.jboss.tools.runtime.test;
 
 import org.jboss.tools.runtime.test.download.DownloadRuntimesTest;
+import org.jboss.tools.runtime.test.extract.UntarUtilityTest;
 import org.jboss.tools.runtime.test.extract.UnzipUtilityTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -23,7 +24,8 @@ import org.junit.runners.Suite;
 	RuntimeDetectionTest.class,
 	DownloadRuntimesTest.class,
 	DownloadRuntimeOperationUtilityTest.class, 
-	UnzipUtilityTest.class
+	UnzipUtilityTest.class,
+	UntarUtilityTest.class
 })
 
 @RunWith(Suite.class)

--- a/runtime/tests/org.jboss.tools.runtime.test/src/org/jboss/tools/runtime/test/extract/UntarUtilityTest.java
+++ b/runtime/tests/org.jboss.tools.runtime.test/src/org/jboss/tools/runtime/test/extract/UntarUtilityTest.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.runtime.test.extract;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.ui.internal.wizards.datatransfer.TarEntry;
+import org.eclipse.ui.internal.wizards.datatransfer.TarOutputStream;
+import org.jboss.tools.runtime.core.extract.ExtractUtility;
+import org.jboss.tools.runtime.core.extract.IOverwrite;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class UntarUtilityTest {
+	
+	private static final String DUMMY_FILE_CONTENT = "this is a file";
+	@Rule
+	public TemporaryFolder tmpFolder = new TemporaryFolder();
+	
+
+	@Test
+	public void runExtractTest() throws Exception {
+		File tmpFolderRoot = tmpFolder.getRoot();
+		File outTar = new File(tmpFolderRoot, "out.tar");
+		File f = createTarFile(outTar, new String[]{"out1.txt", "out2.txt", "same.name", "out3.txt", }, new String[] {"same.name"});
+		File dest = new File(tmpFolderRoot, "out");
+		dest.mkdirs();
+		new ExtractUtility(f).extract(dest, createOverwrite(), new NullProgressMonitor());
+		assertTrue(new File(dest, "out1.txt").exists());
+		assertTrue(new File(dest, "out2.txt").exists());
+		assertTrue(new File(dest, "out3.txt").exists());
+	}
+	
+	private File createTarFile(File out, String[] fileEntries, String[] folderEntries) throws Exception {
+		out.getParentFile().mkdirs();
+		try (FileOutputStream fos = new FileOutputStream(out); TarOutputStream tos = new TarOutputStream(fos); ) {
+			for (String folderEntry : folderEntries) {
+				TarEntry tarEntry = new TarEntry(folderEntry);
+				tarEntry.setFileType(TarEntry.DIRECTORY);
+				tos.putNextEntry(tarEntry);
+				tos.closeEntry();
+			}
+			for(String fileEntry : fileEntries) {
+				addToTarFile(toIS(DUMMY_FILE_CONTENT), fileEntry, tos);
+			}
+		}
+		return out;
+	}
+	
+	private IOverwrite createOverwrite() {
+		return new IOverwrite() {
+			public int overwrite(File file) {
+				return YES;
+			}
+		};
+	}
+	
+	private InputStream toIS(String s) {
+		return new ByteArrayInputStream(s.getBytes());
+	}
+	
+	public static void addToTarFile(InputStream source, String entryName, TarOutputStream tos) throws FileNotFoundException, IOException {
+		System.out.println(entryName);
+		TarEntry tarEntry = new TarEntry(entryName);
+		tarEntry.setSize(DUMMY_FILE_CONTENT.length());
+		tos.putNextEntry(tarEntry);
+		
+		byte[] bytes = new byte[2048];
+		int length;
+		while ((length = source.read(bytes)) > 0) {
+			tos.write(bytes, 0, length);
+		}
+
+		tos.closeEntry();
+		source.close();
+	}
+	
+}


### PR DESCRIPTION
when a tar is containing a file and a directory at the same entry name,
just log it and continue the extraction

I choose to log and continue.
Would you prefer to just throw a better error?