### PR TITLE
JBIDE-25514 remove maven-clean-plugin and...

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.help.ui/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.help.ui/pom.xml
@@ -16,7 +16,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.10</version><!--$NO-MVN-MAN-VER$-->
 				<executions>
 					<execution>
 						<id>get-libs</id>
@@ -42,7 +41,6 @@
 				<!-- make sure lib dir is removed after clean to avoid "dirty" build -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-clean-plugin</artifactId>
-				<version>2.6.1</version><!--$NO-MVN-MAN-VER$-->
 				<configuration>
 					<filesets>
 						<fileset>

--- a/foundation/plugins/org.jboss.tools.foundation.ui/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/pom.xml
@@ -15,7 +15,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.7</version><!--$NO-MVN-MAN-VER$-->
 				<executions>
 					<execution>
 						<id>get-libs</id>


### PR DESCRIPTION
JBIDE-25514 remove maven-clean-plugin and maven-dependency-plugin versions; inherit this from parent pom

Signed-off-by: nickboldt <nboldt@redhat.com>