### PR TITLE
JBIDE-26872 - Fix the update to 4.13.0.Final-SNAPSHOT

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
@@ -9,5 +9,5 @@
 #     Red Hat, Inc. - initial API and implementation
 ##############################################################################
 # set default.version to the same x.y.z base as the parent pom, then .${BUILD_ALIAS} or .Final
-default.version=4.13.0.AM1
+default.version=4.13.0.Final
 version=${jbosstools.version}


### PR DESCRIPTION
Fix the update to 4.13.0.Final-SNAPSHOT. Without this fix the jbosstools-base cannot be build using maven.

**Jira:** https://issues.jboss.org/browse/JBIDE-26872

Please review and merge @sbouchet 