### PR TITLE
JBIDE-26938 - Fix the jbosstools-base blocker - the repo cannot be built after last commit

### DIFF
--- a/foundation/features/org.jboss.tools.foundation.feature/feature.xml
+++ b/foundation/features/org.jboss.tools.foundation.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.foundation.feature"
       label="%featureName"
-      version="1.5.4.qualifier"
+      version="1.6.0.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.foundation.ui"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/foundation/features/org.jboss.tools.foundation.feature/pom.xml
+++ b/foundation/features/org.jboss.tools.foundation.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>features</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.features</groupId>
 	<artifactId>org.jboss.tools.foundation.feature</artifactId> 

--- a/foundation/features/org.jboss.tools.foundation.license.feature/feature.xml
+++ b/foundation/features/org.jboss.tools.foundation.license.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.foundation.license.feature"
       label="JBoss Tools License feature"
-      version="1.5.4.qualifier"
+      version="1.6.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.jboss.org/tools">

--- a/foundation/features/org.jboss.tools.foundation.license.feature/pom.xml
+++ b/foundation/features/org.jboss.tools.foundation.license.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>features</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.features</groupId>
 	<artifactId>org.jboss.tools.foundation.license.feature</artifactId> 

--- a/foundation/features/org.jboss.tools.foundation.security.linux.feature/feature.xml
+++ b/foundation/features/org.jboss.tools.foundation.security.linux.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.foundation.security.linux.feature"
       label="%featureName"
-      version="1.5.4.qualifier"
+      version="1.6.0.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.foundation.security.linux"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/foundation/features/org.jboss.tools.foundation.security.linux.feature/pom.xml
+++ b/foundation/features/org.jboss.tools.foundation.security.linux.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>features</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.features</groupId>
 	<artifactId>org.jboss.tools.foundation.security.linux.feature</artifactId> 

--- a/foundation/features/org.jboss.tools.foundation.test.feature/feature.xml
+++ b/foundation/features/org.jboss.tools.foundation.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.foundation.test.feature"
       label="%featureName"
-      version="1.5.4.qualifier"
+      version="1.6.0.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">

--- a/foundation/features/org.jboss.tools.foundation.test.feature/pom.xml
+++ b/foundation/features/org.jboss.tools.foundation.test.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>features</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.test.features</groupId>
 	<artifactId>org.jboss.tools.foundation.test.feature</artifactId> 

--- a/foundation/features/pom.xml
+++ b/foundation/features/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>	
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>foundation</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<modules>

--- a/foundation/plugins/org.jboss.tools.foundation.checkup/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.checkup/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.ui.workbench;bundle-version="3.107.0",
  org.eclipse.ui.views.log;bundle-version="1.0.600",
  org.eclipse.jface
-Bundle-Version: 1.5.4.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/foundation/plugins/org.jboss.tools.foundation.checkup/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.checkup/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.plugins</groupId>
 	<artifactId>org.jboss.tools.foundation.checkup</artifactId> 

--- a/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.core/META-INF/MANIFEST.MF
@@ -32,7 +32,7 @@ Require-Bundle: org.eclipse.equinox.p2.core;bundle-version="2.2.0",
  org.eclipse.ecf.provider.filetransfer.httpclient45;bundle-version="1.0.0",
  org.eclipse.e4.core.contexts;bundle-version="1.5.0",
  org.eclipse.e4.core.di;bundle-version="1.6.0"
-Bundle-Version: 1.5.4.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.plugins</groupId>
 	<artifactId>org.jboss.tools.foundation.core</artifactId>

--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
@@ -9,5 +9,5 @@
 #     Red Hat, Inc. - initial API and implementation
 ##############################################################################
 # set default.version to the same x.y.z base as the parent pom, then .${BUILD_ALIAS} or .Final
-default.version=4.13.0.Final
+default.version=4.14.0.AM1
 version=${jbosstools.version}

--- a/foundation/plugins/org.jboss.tools.foundation.help.ui/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.help.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-Vendor: %BundleVendor
 Bundle-SymbolicName: org.jboss.tools.foundation.help.ui;singleton:=true
-Bundle-Version: 1.5.4.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.jboss.tools.foundation.help.ui.internal.JBossHelpActivator
 Require-Bundle: org.eclipse.ui,

--- a/foundation/plugins/org.jboss.tools.foundation.help.ui/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.help.ui/pom.xml
@@ -3,7 +3,7 @@
   <parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.plugins</groupId>
 	<artifactId>org.jboss.tools.foundation.help.ui</artifactId>

--- a/foundation/plugins/org.jboss.tools.foundation.security.linux/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.security.linux/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.jboss.tools.foundation.security.linux;singleton:=true
-Bundle-Version: 1.5.4.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.equinox.security;bundle-version="1.1.100"
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/foundation/plugins/org.jboss.tools.foundation.security.linux/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.security.linux/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.plugins</groupId>
 	<artifactId>org.jboss.tools.foundation.security.linux</artifactId> 

--- a/foundation/plugins/org.jboss.tools.foundation.ui/META-INF/MANIFEST.MF
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.9.0",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.2.0",
  org.eclipse.e4.core.contexts;bundle-version="1.5.0",
  org.jboss.tools.foundation.checkup;bundle-version="1.3.2"
-Bundle-Version: 1.5.4.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/foundation/plugins/org.jboss.tools.foundation.ui/pom.xml
+++ b/foundation/plugins/org.jboss.tools.foundation.ui/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.plugins</groupId>
 	<artifactId>org.jboss.tools.foundation.ui</artifactId> 
-	<version>1.5.4-SNAPSHOT</version>
+	<version>1.6.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<build>
 		<plugins>

--- a/foundation/plugins/pom.xml
+++ b/foundation/plugins/pom.xml
@@ -8,7 +8,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <parent>
     <groupId>org.jboss.tools</groupId>
     <artifactId>foundation</artifactId>
-    <version>1.5.4-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
   <modules>

--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>foundation</artifactId>
 	<name>foundation.all</name>
-	<version>1.5.4-SNAPSHOT</version>
+	<version>1.6.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
 		<module>plugins</module>

--- a/foundation/tests/org.jboss.tools.foundation.checkup.test/META-INF/MANIFEST.MF
+++ b/foundation/tests/org.jboss.tools.foundation.checkup.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Foundation Checkup Test
 Bundle-SymbolicName: org.jboss.tools.foundation.checkup.test
-Bundle-Version: 1.5.4.qualifier
+Bundle-Version: 1.6.0.qualifier
 Export-Package: org.jboss.tools.foundation.checkup.test
 Require-Bundle: org.junit,
  org.jboss.tools.foundation.checkup;bundle-version="1.2.0",

--- a/foundation/tests/org.jboss.tools.foundation.checkup.test/pom.xml
+++ b/foundation/tests/org.jboss.tools.foundation.checkup.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.tests</groupId>
 	<artifactId>org.jboss.tools.foundation.checkup.test</artifactId>

--- a/foundation/tests/org.jboss.tools.foundation.core.test/META-INF/MANIFEST.MF
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.foundation.core.test;singleton:=true
-Bundle-Version: 1.5.4.qualifier
+Bundle-Version: 1.6.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.8.1",
  org.eclipse.equinox.http.jetty;bundle-version="3.0.100",

--- a/foundation/tests/org.jboss.tools.foundation.core.test/pom.xml
+++ b/foundation/tests/org.jboss.tools.foundation.core.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.tests</groupId>
 	<artifactId>org.jboss.tools.foundation.core.test</artifactId>

--- a/foundation/tests/org.jboss.tools.foundation.help.test/META-INF/MANIFEST.MF
+++ b/foundation/tests/org.jboss.tools.foundation.help.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Tools Help Plugin - Tests
 Bundle-SymbolicName: org.jboss.tools.foundation.help.test
-Bundle-Version: 1.5.4.qualifier
+Bundle-Version: 1.6.0.qualifier
 Fragment-Host: org.jboss.tools.foundation.help.ui;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/foundation/tests/org.jboss.tools.foundation.help.test/pom.xml
+++ b/foundation/tests/org.jboss.tools.foundation.help.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.tests</groupId>
 	<artifactId>org.jboss.tools.foundation.help.test</artifactId>

--- a/foundation/tests/org.jboss.tools.foundation.ui.test/META-INF/MANIFEST.MF
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Foundation UI Test
 Bundle-SymbolicName: org.jboss.tools.foundation.ui.test;singleton:=true
-Bundle-Version: 1.5.4.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-ClassPath: .
 Export-Package: org.jboss.tools.foundation.ui.test
 Require-Bundle: org.junit,

--- a/foundation/tests/org.jboss.tools.foundation.ui.test/pom.xml
+++ b/foundation/tests/org.jboss.tools.foundation.ui.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.foundation</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.5.4-SNAPSHOT</version>
+		<version>1.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.foundation.tests</groupId>
 	<artifactId>org.jboss.tools.foundation.ui.test</artifactId>

--- a/foundation/tests/pom.xml
+++ b/foundation/tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.tools</groupId>
     <artifactId>foundation</artifactId>
-    <version>1.5.4-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.foundation</groupId>
   <artifactId>tests</artifactId>


### PR DESCRIPTION
**JBIDE-26938 - Fix the following error:**
   [ERROR] Invalid value of default.version = 4.13.0.Final for parent = 4.14.0.AM1-SNAPSHOT !
   Must set default.version = 4.14.0.Final (or = 4.14.0.AM1) in this file:
   /Users/zcervink/git/jbosstools-base/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>


**Jira:** https://issues.jboss.org/browse/JBIDE-26938
Please review @sbouchet @jeffmaury 