### PR TITLE
JBIDE-27035 - fix the jbosstools-base repo that cannot be build after last commit due to not bumped up version

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
@@ -9,5 +9,5 @@
 #     Red Hat, Inc. - initial API and implementation
 ##############################################################################
 # set default.version to the same x.y.z base as the parent pom, then .${BUILD_ALIAS} or .Final
-default.version=4.14.0.AM1
+default.version=4.14.0.Final
 version=${jbosstools.version}


### PR DESCRIPTION
Fix the jbosstools-base repo that cannot be build after last commit due to not bumped up version

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

Please review @sbouchet 

**See the output of terminal - build is successful:**

```
[INFO] Reactor Summary:
[INFO] 
[INFO] jbosstools-base 4.5.0-SNAPSHOT ..................... SUCCESS [  0.384 s]
[INFO] tests.all 3.7.103-SNAPSHOT ......................... SUCCESS [  0.018 s]
[INFO] tests.plugins 3.7.103-SNAPSHOT ..................... SUCCESS [  0.019 s]
[INFO] org.jboss.tools.tests 3.7.103-SNAPSHOT ............. SUCCESS [ 11.885 s]
[INFO] tests.tests 3.7.103-SNAPSHOT ....................... SUCCESS [  0.014 s]
[INFO] org.jboss.tools.tests.test 3.7.103-SNAPSHOT ........ SUCCESS [  0.314 s]
[INFO] tests.features 3.7.103-SNAPSHOT .................... SUCCESS [  0.015 s]
[INFO] foundation.all 1.6.0-SNAPSHOT ...................... SUCCESS [  0.013 s]
[INFO] foundation.features 1.6.0-SNAPSHOT ................. SUCCESS [  0.014 s]
[INFO] org.jboss.tools.foundation.license.feature 1.6.0-SNAPSHOT SUCCESS [  0.221 s]
[INFO] org.jboss.tools.test.feature 3.7.103-SNAPSHOT ...... SUCCESS [  0.298 s]
[INFO] foundation.plugins 1.6.0-SNAPSHOT .................. SUCCESS [  0.013 s]
[INFO] org.jboss.tools.foundation.core 1.6.0-SNAPSHOT ..... SUCCESS [  1.461 s]
[INFO] org.jboss.tools.foundation.checkup 1.6.0-SNAPSHOT .. SUCCESS [  0.355 s]
[INFO] org.jboss.tools.foundation.ui 1.6.0-SNAPSHOT ....... SUCCESS [  0.819 s]
[INFO] org.jboss.tools.foundation.security.linux 1.6.0-SNAPSHOT SUCCESS [  0.256 s]
[INFO] org.jboss.tools.foundation.help.ui 1.6.0-SNAPSHOT .. SUCCESS [  0.304 s]
[INFO] org.jboss.tools.foundation.feature 1.6.0-SNAPSHOT .. SUCCESS [  0.282 s]
[INFO] org.jboss.tools.foundation.security.linux.feature 1.6.0-SNAPSHOT SUCCESS [  0.234 s]
[INFO] foundation.tests 1.6.0-SNAPSHOT .................... SUCCESS [  0.023 s]
[INFO] org.jboss.tools.foundation.checkup.test 1.6.0-SNAPSHOT SUCCESS [  0.271 s]
[INFO] org.jboss.tools.foundation.core.test 1.6.0-SNAPSHOT  SUCCESS [  0.408 s]
[INFO] org.jboss.tools.foundation.help.test 1.6.0-SNAPSHOT  SUCCESS [  0.299 s]
[INFO] org.jboss.tools.foundation.ui.test 1.6.0-SNAPSHOT .. SUCCESS [  0.292 s]
[INFO] org.jboss.tools.foundation.test.feature 1.6.0-SNAPSHOT SUCCESS [  0.306 s]
[INFO] common.all 3.12.0-SNAPSHOT ......................... SUCCESS [  0.015 s]
[INFO] common.plugins 3.12.0-SNAPSHOT ..................... SUCCESS [  0.014 s]
[INFO] org.jboss.tools.common.core 3.12.0-SNAPSHOT ........ SUCCESS [  0.618 s]
[INFO] org.jboss.tools.common 3.12.0-SNAPSHOT ............. SUCCESS [  0.551 s]
[INFO] org.jboss.tools.common.resref.core 3.12.0-SNAPSHOT . SUCCESS [  0.252 s]
[INFO] org.jboss.tools.common.el.core 3.12.0-SNAPSHOT ..... SUCCESS [  0.714 s]
[INFO] org.jboss.tools.common.model.ui.capabilities 3.12.0-SNAPSHOT SUCCESS [  0.144 s]
[INFO] org.jboss.tools.common.model 3.12.0-SNAPSHOT ....... SUCCESS [  1.934 s]
[INFO] org.jboss.tools.common.text.xml 3.12.0-SNAPSHOT .... SUCCESS [  0.568 s]
[INFO] org.jboss.tools.common.validation 3.12.0-SNAPSHOT .. SUCCESS [  0.555 s]
[INFO] org.jboss.tools.common.ui 3.12.0-SNAPSHOT .......... SUCCESS [  0.740 s]
[INFO] org.jboss.tools.common.text.ext 3.12.0-SNAPSHOT .... SUCCESS [  0.801 s]
[INFO] org.jboss.tools.common.model.ui 3.12.0-SNAPSHOT .... SUCCESS [  2.502 s]
[INFO] org.jboss.tools.common.el.ui 3.12.0-SNAPSHOT ....... SUCCESS [  0.575 s]
[INFO] org.jboss.tools.common.gef 3.12.0-SNAPSHOT ......... SUCCESS [  0.509 s]
[INFO] org.jboss.tools.common.meta.ui 3.12.0-SNAPSHOT ..... SUCCESS [  0.709 s]
[INFO] org.jboss.tools.common.projecttemplates 3.12.0-SNAPSHOT SUCCESS [  0.726 s]
[INFO] org.jboss.tools.common.resref.ui 3.12.0-SNAPSHOT ... SUCCESS [  0.424 s]
[INFO] org.jboss.tools.common.verification 3.12.0-SNAPSHOT  SUCCESS [  0.516 s]
[INFO] org.jboss.tools.common.verification.ui 3.12.0-SNAPSHOT SUCCESS [  0.566 s]
[INFO] org.jboss.tools.common.jdt.debug 3.12.0-SNAPSHOT ... SUCCESS [  0.238 s]
[INFO] org.jboss.tools.common.jdt.debug.ui 3.12.0-SNAPSHOT  SUCCESS [  0.355 s]
[INFO] org.jboss.tools.common.jdt 3.12.0-SNAPSHOT ......... SUCCESS [  0.336 s]
[INFO] org.jboss.tools.common.jdt.ui 3.12.0-SNAPSHOT ...... SUCCESS [  0.414 s]
[INFO] org.jboss.tools.common.mylyn 3.12.0-SNAPSHOT ....... SUCCESS [  0.137 s]
[INFO] org.jboss.tools.common.jaxb 3.12.0-SNAPSHOT ........ SUCCESS [  0.212 s]
[INFO] common.features 3.12.0-SNAPSHOT .................... SUCCESS [  0.016 s]
[INFO] org.jboss.tools.common.core.feature 3.12.0-SNAPSHOT  SUCCESS [  0.246 s]
[INFO] org.jboss.tools.common.feature 3.12.0-SNAPSHOT ..... SUCCESS [  0.272 s]
[INFO] org.jboss.tools.common.text.ext.feature 3.12.0-SNAPSHOT SUCCESS [  0.252 s]
[INFO] org.jboss.tools.common.ui.feature 3.12.0-SNAPSHOT .. SUCCESS [  0.241 s]
[INFO] org.jboss.tools.common.verification.feature 3.12.0-SNAPSHOT SUCCESS [  0.205 s]
[INFO] org.jboss.tools.common.all.feature 3.12.0-SNAPSHOT . SUCCESS [  0.380 s]
[INFO] common.test-framework 3.12.0-SNAPSHOT .............. SUCCESS [  0.010 s]
[INFO] org.jboss.tools.common.reddeer 3.12.0-SNAPSHOT ..... SUCCESS [  0.513 s]
[INFO] common.tests 3.12.0-SNAPSHOT ....................... SUCCESS [  0.009 s]
[INFO] org.jboss.tools.common.core.test 3.12.0-SNAPSHOT ... SUCCESS [  0.440 s]
[INFO] org.jboss.tools.common.test 3.12.0-SNAPSHOT ........ SUCCESS [  0.357 s]
[INFO] org.jboss.tools.common.el.core.test 3.12.0-SNAPSHOT  SUCCESS [  0.433 s]
[INFO] org.jboss.tools.common.model.test 3.12.0-SNAPSHOT .. SUCCESS [  0.537 s]
[INFO] org.jboss.tools.common.model.ui.test 3.12.0-SNAPSHOT SUCCESS [  0.419 s]
[INFO] org.jboss.tools.common.base.test 3.12.0-SNAPSHOT ... SUCCESS [  0.535 s]
[INFO] org.jboss.tools.common.validation.test 3.12.0-SNAPSHOT SUCCESS [  0.408 s]
[INFO] org.jboss.tools.common.verification.test 3.12.0-SNAPSHOT SUCCESS [  0.358 s]
[INFO] org.jboss.tools.common.verification.ui.test 3.12.0-SNAPSHOT SUCCESS [  0.400 s]
[INFO] org.jboss.tools.common.ui.test 3.12.0-SNAPSHOT ..... SUCCESS [  0.370 s]
[INFO] org.jboss.tools.common.text.ext.test 3.12.0-SNAPSHOT SUCCESS [  0.413 s]
[INFO] org.jboss.tools.common.mylyn.test 3.8.100-SNAPSHOT . SUCCESS [  0.232 s]
[INFO] org.jboss.tools.common.all.test.feature 3.8.200-SNAPSHOT SUCCESS [  0.439 s]
[INFO] org.jboss.tools.common.jdt.feature 3.12.0-SNAPSHOT . SUCCESS [  0.228 s]
[INFO] org.jboss.tools.common.mylyn.feature 3.12.0-SNAPSHOT SUCCESS [  0.158 s]
[INFO] stacks.all 1.4.102-SNAPSHOT ........................ SUCCESS [  0.009 s]
[INFO] stacks.plugins 1.4.102-SNAPSHOT .................... SUCCESS [  0.009 s]
[INFO] org.jboss.tools.stacks.core 1.4.102-SNAPSHOT ....... SUCCESS [  1.721 s]
[INFO] stacks.tests 1.4.102-SNAPSHOT ...................... SUCCESS [  0.009 s]
[INFO] org.jboss.tools.stacks.core.test 1.4.102-SNAPSHOT .. SUCCESS [  0.324 s]
[INFO] stacks.features 1.4.102-SNAPSHOT ................... SUCCESS [  0.010 s]
[INFO] org.jboss.tools.stacks.core.feature 1.4.102-SNAPSHOT SUCCESS [  1.461 s]
[INFO] org.jboss.tools.stacks.core.test.feature 1.4.102-SNAPSHOT SUCCESS [  0.171 s]
[INFO] runtime.all 3.5.0-SNAPSHOT ......................... SUCCESS [  0.010 s]
[INFO] runtime.plugins 3.5.0-SNAPSHOT ..................... SUCCESS [  0.011 s]
[INFO] org.jboss.tools.runtime.core 3.5.0-SNAPSHOT ........ SUCCESS [  1.227 s]
[INFO] org.jboss.tools.runtime.ui 3.5.0-SNAPSHOT .......... SUCCESS [  1.322 s]
[INFO] runtime.test-framework 3.5.0-SNAPSHOT .............. SUCCESS [  0.011 s]
[INFO] org.jboss.tools.runtime.reddeer 3.5.0-SNAPSHOT ..... SUCCESS [  0.245 s]
[INFO] runtime.tests 3.5.0-SNAPSHOT ....................... SUCCESS [  0.010 s]
[INFO] org.jboss.tools.runtime.test 3.5.0-SNAPSHOT ........ SUCCESS [  0.372 s]
[INFO] runtime.features 3.5.0-SNAPSHOT .................... SUCCESS [  0.011 s]
[INFO] org.jboss.tools.runtime.core.feature 3.5.0-SNAPSHOT  SUCCESS [  0.721 s]
[INFO] org.jboss.tools.runtime.test.feature 3.5.0-SNAPSHOT  SUCCESS [  0.201 s]
[INFO] usage.all 2.2.202-SNAPSHOT ......................... SUCCESS [  0.010 s]
[INFO] usage.plugins 2.2.202-SNAPSHOT ..................... SUCCESS [  0.009 s]
[INFO] org.jboss.tools.usage 2.2.202-SNAPSHOT ............. SUCCESS [  1.371 s]
[INFO] usage.tests 2.2.202-SNAPSHOT ....................... SUCCESS [  0.010 s]
[INFO] org.jboss.tools.usage.test 2.2.202-SNAPSHOT ........ SUCCESS [  0.350 s]
[INFO] usage.features 2.2.202-SNAPSHOT .................... SUCCESS [  0.009 s]
[INFO] org.jboss.tools.usage.feature 2.2.202-SNAPSHOT ..... SUCCESS [  0.777 s]
[INFO] org.jboss.tools.usage.test.feature 2.2.202-SNAPSHOT  SUCCESS [  0.167 s]
[INFO] base.site 4.5.0-SNAPSHOT ........................... SUCCESS [  7.698 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:30 min
[INFO] Finished at: 2020-01-30T12:44:06+01:00
[INFO] ------------------------------------------------------------------------
```