### PR TITLE
Added null reference check for JBossToolsUsageActivator.branding field.

### DIFF
--- a/jacoco-report/pom.xml
+++ b/jacoco-report/pom.xml
@@ -20,7 +20,7 @@
 		<plugins.version.runtime>3.5.1-SNAPSHOT</plugins.version.runtime>
 		<plugins.version.stacks>1.4.103-SNAPSHOT</plugins.version.stacks>
 		<plugins.version.tests>3.7.103-SNAPSHOT</plugins.version.tests>
-		<plugins.version.usage>2.2.203-SNAPSHOT</plugins.version.usage>
+		<plugins.version.usage>2.2.300-SNAPSHOT</plugins.version.usage>
 	</properties>
 
 	<build>

--- a/usage/features/org.jboss.tools.usage.feature/feature.xml
+++ b/usage/features/org.jboss.tools.usage.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.usage.feature"
       label="%featureName"
-      version="2.2.203.qualifier"
+      version="2.2.300.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.usage"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/usage/features/org.jboss.tools.usage.feature/pom.xml
+++ b/usage/features/org.jboss.tools.usage.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.usage</groupId>
 		<artifactId>features</artifactId>
-		<version>2.2.203-SNAPSHOT</version>
+		<version>2.2.300-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.usage.features</groupId>
 	<artifactId>org.jboss.tools.usage.feature</artifactId>

--- a/usage/features/org.jboss.tools.usage.test.feature/feature.xml
+++ b/usage/features/org.jboss.tools.usage.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.usage.test.feature"
       label="%featureName"
-      version="2.2.203.qualifier"
+      version="2.2.300.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">

--- a/usage/features/org.jboss.tools.usage.test.feature/pom.xml
+++ b/usage/features/org.jboss.tools.usage.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.usage</groupId>
 		<artifactId>features</artifactId>
-		<version>2.2.203-SNAPSHOT</version>
+		<version>2.2.300-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.usage.features</groupId>
 	<artifactId>org.jboss.tools.usage.test.feature</artifactId>

--- a/usage/features/pom.xml
+++ b/usage/features/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>usage</artifactId>
-		<version>2.2.203-SNAPSHOT</version>
+		<version>2.2.300-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.usage</groupId>
 	<artifactId>features</artifactId>

--- a/usage/plugins/org.jboss.tools.usage/META-INF/MANIFEST.MF
+++ b/usage/plugins/org.jboss.tools.usage/META-INF/MANIFEST.MF
@@ -21,9 +21,7 @@ Export-Package: org.jboss.tools.usage.branding,
  org.jboss.tools.usage.util.reader
 Require-Bundle: org.eclipse.osgi;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.epp.logging.aeri.core;bundle-version="1.100.0";resolution:=optional;x-installation:=greedy,
- org.eclipse.epp.logging.aeri.ide;bundle-version="1.100.0";resolution:=optional;x-installation:=greedy
+ org.eclipse.ui;bundle-version="[3.5.0,4.0.0)"
 Bundle-Activator: org.jboss.tools.usage.internal.JBossToolsUsageActivator
 Bundle-Vendor: %bundle-vendor
 Bundle-ActivationPolicy: lazy

--- a/usage/plugins/org.jboss.tools.usage/META-INF/MANIFEST.MF
+++ b/usage/plugins/org.jboss.tools.usage/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundle-name
 Bundle-SymbolicName: org.jboss.tools.usage;singleton:=true
-Bundle-Version: 2.2.203.qualifier
+Bundle-Version: 2.2.300.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.jboss.tools.usage.branding,
  org.jboss.tools.usage.event,

--- a/usage/plugins/org.jboss.tools.usage/plugin.xml
+++ b/usage/plugins/org.jboss.tools.usage/plugin.xml
@@ -23,29 +23,5 @@
       </initializer>
    </extension>
    
-   <extension
-         point="org.eclipse.epp.logging.aeri.ide.servers">
-      <server 
-            id="org.jboss.tools"
-            class="org.eclipse.epp.internal.logging.aeri.ide.server.mars.ServerConnection"
-            icon16="icons/obj16/jbosstools.png"
-            icon32="icons/obj32/jbosstools.png"
-            icon64="icons/obj64/jbosstools.png"
-            name="JBoss Tools"
-            description="JBoss Tools wishes to get notified about errors that occur in - or may affect the usability of - JBoss Tools. See &lt;a href=&quot;http://tools.jboss.org/usage/&quot;&gt;JBoss Usage Reporting&lt;/a&gt; For details on privacy and data usage."
-            >
-             <link
-               href="https://www.redhat.com"
-               rel="provider"
-               title="Red Hat, Inc.">
-         </link>
-         <!-- test that redirects to https://redhat.ctrlflow.com/rest/2.0/community/discovery" -->
-         <link
-               href="https://tools.jboss.org/usage/errors/rest/2.0/community/discovery" 
-               rel="discovery"
-               title="Discovery URL">
-         </link>
-      </server>
-   </extension>
    
 </plugin>

--- a/usage/plugins/org.jboss.tools.usage/pom.xml
+++ b/usage/plugins/org.jboss.tools.usage/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.usage</groupId>
 		<artifactId>plugins</artifactId>
-		<version>2.2.203-SNAPSHOT</version>
+		<version>2.2.300-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.usage.plugins</groupId>
 	<artifactId>org.jboss.tools.usage</artifactId>

--- a/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/JBossToolsUsageActivator.java
+++ b/usage/plugins/org.jboss.tools.usage/src/org/jboss/tools/usage/internal/JBossToolsUsageActivator.java
@@ -42,8 +42,10 @@ public class JBossToolsUsageActivator extends Plugin {
 	@Override
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
-		branding.close();
-		this.branding = null;
+		if (branding != null ) {
+			branding.close();
+			this.branding = null;
+		}
 		super.stop(context);
 	}
 

--- a/usage/plugins/pom.xml
+++ b/usage/plugins/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>usage</artifactId>
-		<version>2.2.203-SNAPSHOT</version>
+		<version>2.2.300-SNAPSHOT</version>
 	</parent>	
 	<groupId>org.jboss.tools.usage</groupId>
 	<artifactId>plugins</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>usage</artifactId>
-	<version>2.2.203-SNAPSHOT</version>
+	<version>2.2.300-SNAPSHOT</version>
 	<name>usage.all</name>
 	<packaging>pom</packaging>
 	<modules>

--- a/usage/tests/org.jboss.tools.usage.test/META-INF/MANIFEST.MF
+++ b/usage/tests/org.jboss.tools.usage.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %BundleName
 Bundle-Vendor: %BundleVendor
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.jboss.tools.usage.test
-Bundle-Version: 2.2.203.qualifier
+Bundle-Version: 2.2.300.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.jboss.tools.usage;bundle-version="1.0.0",
  org.eclipse.osgi;bundle-version="3.5.2",

--- a/usage/tests/org.jboss.tools.usage.test/pom.xml
+++ b/usage/tests/org.jboss.tools.usage.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.usage</groupId>
 		<artifactId>tests</artifactId>
-		<version>2.2.203-SNAPSHOT</version>
+		<version>2.2.300-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.usage.tests</groupId>
 	<artifactId>org.jboss.tools.usage.test</artifactId>

--- a/usage/tests/pom.xml
+++ b/usage/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>usage</artifactId>
-		<version>2.2.203-SNAPSHOT</version>
+		<version>2.2.300-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.usage</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
 This PR is to resolve the issue reported at [JBDS-4788](https://issues.redhat.com/browse/JBDS-4788).
 The change adds a null reference condition.