### PR TITLE
JBIDE-27345 - jbosstools-base cannot be built due to not bumped up version

### DIFF
--- a/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
+++ b/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties
@@ -9,5 +9,5 @@
 #     Red Hat, Inc. - initial API and implementation
 ##############################################################################
 # set default.version to the same x.y.z base as the parent pom, then .${BUILD_ALIAS} or .Final
-default.version=4.16.0.AM1
+default.version=4.16.0.Final
 version=${jbosstools.version}


### PR DESCRIPTION
Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

**Jira:** https://issues.redhat.com/browse/JBIDE-27345

Please review @jeffmaury or @sbouchet 


### Error description on localhost before fix:
```
[ERROR] Invalid value of default.version = 4.16.0.AM1 for parent = 4.16.0.Final-SNAPSHOT !

Must set default.version = 4.16.0.Final (or = 4.16.0.Final) in this file:

/Users/zcervink/git/jbosstools-base/foundation/plugins/org.jboss.tools.foundation.core/src/org/jboss/tools/foundation/core/properties/internal/currentversion.properties


...


[*INFO*] BUILD FAILURE

[*INFO*] ------------------------------------------------------------------------

[*INFO*] Total time:  40.428 s

[*INFO*] Finished at: 2020-06-25T13:44:53+02:00

[*INFO*] ------------------------------------------------------------------------

[*ERROR*] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:1.4.1:enforce (foundation-core-default-version-check) on project org.jboss.tools.foundation.core: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]

[*ERROR*]

[*ERROR*] To see the full stack trace of the errors, re-run Maven with the -e switch.

[*ERROR*] Re-run Maven using the -X switch to enable full debug logging.

[*ERROR*]

[*ERROR*] For more information about the errors and possible solutions, please read the following articles:

[*ERROR*] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

[*ERROR*]

[*ERROR*] After correcting the problems, you can resume the build with the command

[*ERROR*]   mvn <args> -rf :org.jboss.tools.foundation.core
```


### Terminal output after fix:
```
[INFO] Reactor Summary:
[INFO] 
[INFO] jbosstools-base 4.5.0-SNAPSHOT ..................... SUCCESS [  0.406 s]
[INFO] tests.all 3.7.103-SNAPSHOT ......................... SUCCESS [  0.014 s]
[INFO] tests.plugins 3.7.103-SNAPSHOT ..................... SUCCESS [  0.014 s]
[INFO] org.jboss.tools.tests 3.7.103-SNAPSHOT ............. SUCCESS [ 11.238 s]
[INFO] tests.tests 3.7.103-SNAPSHOT ....................... SUCCESS [  0.011 s]
[INFO] org.jboss.tools.tests.test 3.7.103-SNAPSHOT ........ SUCCESS [  0.269 s]
[INFO] tests.features 3.7.103-SNAPSHOT .................... SUCCESS [  0.011 s]
[INFO] foundation.all 1.6.200-SNAPSHOT .................... SUCCESS [  0.010 s]
[INFO] foundation.features 1.6.200-SNAPSHOT ............... SUCCESS [  0.010 s]
[INFO] org.jboss.tools.foundation.license.feature 1.6.200-SNAPSHOT SUCCESS [  0.225 s]
[INFO] org.jboss.tools.test.feature 3.7.103-SNAPSHOT ...... SUCCESS [  0.210 s]
[INFO] foundation.plugins 1.6.200-SNAPSHOT ................ SUCCESS [  0.009 s]
[INFO] org.jboss.tools.foundation.core 1.6.200-SNAPSHOT ... SUCCESS [  1.467 s]
[INFO] org.jboss.tools.foundation.checkup 1.6.200-SNAPSHOT  SUCCESS [  0.273 s]
[INFO] org.jboss.tools.foundation.ui 1.6.200-SNAPSHOT ..... SUCCESS [  0.623 s]
[INFO] org.jboss.tools.foundation.security.linux 1.6.200-SNAPSHOT SUCCESS [  0.239 s]
[INFO] org.jboss.tools.foundation.help.ui 1.6.200-SNAPSHOT  SUCCESS [  0.230 s]
[INFO] org.jboss.tools.foundation.feature 1.6.200-SNAPSHOT  SUCCESS [  0.189 s]
[INFO] org.jboss.tools.foundation.security.linux.feature 1.6.200-SNAPSHOT SUCCESS [  0.147 s]
[INFO] foundation.tests 1.6.200-SNAPSHOT .................. SUCCESS [  0.009 s]
[INFO] org.jboss.tools.foundation.checkup.test 1.6.200-SNAPSHOT SUCCESS [  0.202 s]
[INFO] org.jboss.tools.foundation.core.test 1.6.200-SNAPSHOT SUCCESS [  0.282 s]
[INFO] org.jboss.tools.foundation.help.test 1.6.200-SNAPSHOT SUCCESS [  0.238 s]
[INFO] org.jboss.tools.foundation.ui.test 1.6.200-SNAPSHOT  SUCCESS [  0.264 s]
[INFO] org.jboss.tools.foundation.test.feature 1.6.200-SNAPSHOT SUCCESS [  0.216 s]
[INFO] common.all 3.14.0-SNAPSHOT ......................... SUCCESS [  0.009 s]
[INFO] common.plugins 3.14.0-SNAPSHOT ..................... SUCCESS [  0.010 s]
[INFO] org.jboss.tools.common.core 3.14.0-SNAPSHOT ........ SUCCESS [  0.516 s]
[INFO] org.jboss.tools.common 3.14.0-SNAPSHOT ............. SUCCESS [  0.473 s]
[INFO] org.jboss.tools.common.resref.core 3.14.0-SNAPSHOT . SUCCESS [  0.196 s]
[INFO] org.jboss.tools.common.el.core 3.14.0-SNAPSHOT ..... SUCCESS [  0.605 s]
[INFO] org.jboss.tools.common.model.ui.capabilities 3.14.0-SNAPSHOT SUCCESS [  0.115 s]
[INFO] org.jboss.tools.common.model 3.14.0-SNAPSHOT ....... SUCCESS [  1.686 s]
[INFO] org.jboss.tools.common.text.xml 3.14.0-SNAPSHOT .... SUCCESS [  0.536 s]
[INFO] org.jboss.tools.common.validation 3.14.0-SNAPSHOT .. SUCCESS [  0.461 s]
[INFO] org.jboss.tools.common.ui 3.14.0-SNAPSHOT .......... SUCCESS [  0.710 s]
[INFO] org.jboss.tools.common.text.ext 3.14.0-SNAPSHOT .... SUCCESS [  0.788 s]
[INFO] org.jboss.tools.common.model.ui 3.14.0-SNAPSHOT .... SUCCESS [  2.384 s]
[INFO] org.jboss.tools.common.el.ui 3.14.0-SNAPSHOT ....... SUCCESS [  0.583 s]
[INFO] org.jboss.tools.common.gef 3.14.0-SNAPSHOT ......... SUCCESS [  0.444 s]
[INFO] org.jboss.tools.common.meta.ui 3.14.0-SNAPSHOT ..... SUCCESS [  0.584 s]
[INFO] org.jboss.tools.common.projecttemplates 3.14.0-SNAPSHOT SUCCESS [  0.482 s]
[INFO] org.jboss.tools.common.resref.ui 3.14.0-SNAPSHOT ... SUCCESS [  0.480 s]
[INFO] org.jboss.tools.common.verification 3.14.0-SNAPSHOT  SUCCESS [  0.427 s]
[INFO] org.jboss.tools.common.verification.ui 3.14.0-SNAPSHOT SUCCESS [  0.556 s]
[INFO] org.jboss.tools.common.jdt.debug 3.14.0-SNAPSHOT ... SUCCESS [  0.198 s]
[INFO] org.jboss.tools.common.jdt.debug.ui 3.14.0-SNAPSHOT  SUCCESS [  0.326 s]
[INFO] org.jboss.tools.common.jdt 3.14.0-SNAPSHOT ......... SUCCESS [  0.309 s]
[INFO] org.jboss.tools.common.jdt.ui 3.14.0-SNAPSHOT ...... SUCCESS [  0.335 s]
[INFO] org.jboss.tools.common.mylyn 3.14.0-SNAPSHOT ....... SUCCESS [  0.105 s]
[INFO] org.jboss.tools.common.jaxb 3.14.0-SNAPSHOT ........ SUCCESS [  0.171 s]
[INFO] common.features 3.14.0-SNAPSHOT .................... SUCCESS [  0.008 s]
[INFO] org.jboss.tools.common.core.feature 3.14.0-SNAPSHOT  SUCCESS [  0.221 s]
[INFO] org.jboss.tools.common.feature 3.14.0-SNAPSHOT ..... SUCCESS [  0.222 s]
[INFO] org.jboss.tools.common.text.ext.feature 3.14.0-SNAPSHOT SUCCESS [  0.182 s]
[INFO] org.jboss.tools.common.ui.feature 3.14.0-SNAPSHOT .. SUCCESS [  0.214 s]
[INFO] org.jboss.tools.common.verification.feature 3.14.0-SNAPSHOT SUCCESS [  0.167 s]
[INFO] org.jboss.tools.common.all.feature 3.14.0-SNAPSHOT . SUCCESS [  0.290 s]
[INFO] common.test-framework 3.14.0-SNAPSHOT .............. SUCCESS [  0.007 s]
[INFO] org.jboss.tools.common.reddeer 3.14.0-SNAPSHOT ..... SUCCESS [  0.471 s]
[INFO] common.tests 3.14.0-SNAPSHOT ....................... SUCCESS [  0.007 s]
[INFO] org.jboss.tools.common.core.test 3.14.0-SNAPSHOT ... SUCCESS [  0.373 s]
[INFO] org.jboss.tools.common.test 3.14.0-SNAPSHOT ........ SUCCESS [  0.310 s]
[INFO] org.jboss.tools.common.el.core.test 3.14.0-SNAPSHOT  SUCCESS [  0.429 s]
[INFO] org.jboss.tools.common.model.test 3.14.0-SNAPSHOT .. SUCCESS [  0.428 s]
[INFO] org.jboss.tools.common.model.ui.test 3.14.0-SNAPSHOT SUCCESS [  0.423 s]
[INFO] org.jboss.tools.common.base.test 3.14.0-SNAPSHOT ... SUCCESS [  0.458 s]
[INFO] org.jboss.tools.common.validation.test 3.14.0-SNAPSHOT SUCCESS [  0.398 s]
[INFO] org.jboss.tools.common.verification.test 3.14.0-SNAPSHOT SUCCESS [  0.316 s]
[INFO] org.jboss.tools.common.verification.ui.test 3.14.0-SNAPSHOT SUCCESS [  0.362 s]
[INFO] org.jboss.tools.common.ui.test 3.14.0-SNAPSHOT ..... SUCCESS [  0.367 s]
[INFO] org.jboss.tools.common.text.ext.test 3.14.0-SNAPSHOT SUCCESS [  0.356 s]
[INFO] org.jboss.tools.common.mylyn.test 3.8.100-SNAPSHOT . SUCCESS [  0.195 s]
[INFO] org.jboss.tools.common.all.test.feature 3.8.200-SNAPSHOT SUCCESS [  0.373 s]
[INFO] org.jboss.tools.common.jdt.feature 3.14.0-SNAPSHOT . SUCCESS [  0.186 s]
[INFO] org.jboss.tools.common.mylyn.feature 3.14.0-SNAPSHOT SUCCESS [  0.138 s]
[INFO] stacks.all 1.4.103-SNAPSHOT ........................ SUCCESS [  0.008 s]
[INFO] stacks.plugins 1.4.103-SNAPSHOT .................... SUCCESS [  0.008 s]
[INFO] org.jboss.tools.stacks.core 1.4.103-SNAPSHOT ....... SUCCESS [  3.078 s]
[INFO] stacks.tests 1.4.103-SNAPSHOT ...................... SUCCESS [  0.009 s]
[INFO] org.jboss.tools.stacks.core.test 1.4.103-SNAPSHOT .. SUCCESS [  0.292 s]
[INFO] stacks.features 1.4.103-SNAPSHOT ................... SUCCESS [  0.008 s]
[INFO] org.jboss.tools.stacks.core.feature 1.4.103-SNAPSHOT SUCCESS [  1.215 s]
[INFO] org.jboss.tools.stacks.core.test.feature 1.4.103-SNAPSHOT SUCCESS [  0.147 s]
[INFO] runtime.all 3.5.1-SNAPSHOT ......................... SUCCESS [  0.008 s]
[INFO] runtime.plugins 3.5.1-SNAPSHOT ..................... SUCCESS [  0.007 s]
[INFO] org.jboss.tools.runtime.core 3.5.1-SNAPSHOT ........ SUCCESS [  2.377 s]
[INFO] org.jboss.tools.runtime.ui 3.5.1-SNAPSHOT .......... SUCCESS [  5.371 s]
[INFO] runtime.test-framework 3.5.1-SNAPSHOT .............. SUCCESS [  0.009 s]
[INFO] org.jboss.tools.runtime.reddeer 3.5.1-SNAPSHOT ..... SUCCESS [  0.203 s]
[INFO] runtime.tests 3.5.1-SNAPSHOT ....................... SUCCESS [  0.008 s]
[INFO] org.jboss.tools.runtime.test 3.5.1-SNAPSHOT ........ SUCCESS [  0.353 s]
[INFO] runtime.features 3.5.1-SNAPSHOT .................... SUCCESS [  0.008 s]
[INFO] org.jboss.tools.runtime.core.feature 3.5.1-SNAPSHOT  SUCCESS [  1.358 s]
[INFO] org.jboss.tools.runtime.test.feature 3.5.1-SNAPSHOT  SUCCESS [  0.155 s]
[INFO] usage.all 2.2.300-SNAPSHOT ......................... SUCCESS [  0.007 s]
[INFO] usage.plugins 2.2.300-SNAPSHOT ..................... SUCCESS [  0.007 s]
[INFO] org.jboss.tools.usage 2.2.300-SNAPSHOT ............. SUCCESS [  3.069 s]
[INFO] usage.tests 2.2.300-SNAPSHOT ....................... SUCCESS [  0.008 s]
[INFO] org.jboss.tools.usage.test 2.2.300-SNAPSHOT ........ SUCCESS [  0.226 s]
[INFO] usage.features 2.2.300-SNAPSHOT .................... SUCCESS [  0.008 s]
[INFO] org.jboss.tools.usage.feature 2.2.300-SNAPSHOT ..... SUCCESS [  1.273 s]
[INFO] org.jboss.tools.usage.test.feature 2.2.300-SNAPSHOT  SUCCESS [  0.143 s]
[INFO] base.site 4.5.0-SNAPSHOT ........................... SUCCESS [  6.094 s]
[INFO] Base JaCoCo Report 4.5.0-SNAPSHOT .................. SUCCESS [  4.286 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:30 min
[INFO] Finished at: 2020-06-25T14:33:18+02:00
[INFO] ------------------------------------------------------------------------
```
