### PR TITLE
Add range for javax.activation

### DIFF
--- a/common/features/org.jboss.tools.common.all.feature/feature.xml
+++ b/common/features/org.jboss.tools.common.all.feature/feature.xml
@@ -1,24 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="org.jboss.tools.common.all.feature" label="%featureName" version="3.15.0.qualifier" provider-name="%featureProvider"
-	plugin="org.jboss.tools.common.el.ui"
-	license-feature="org.jboss.tools.foundation.license.feature"
-	license-feature-version="0.0.0">
+<feature
+      id="org.jboss.tools.common.all.feature"
+      label="%featureName"
+      version="3.15.100.qualifier"
+      provider-name="%featureProvider"
+      plugin="org.jboss.tools.common.el.ui"
+      license-feature="org.jboss.tools.foundation.license.feature"
+      license-feature-version="0.0.0">
 
-	<description>%description</description>
-	<copyright>%copyright</copyright>
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      %copyright
+   </copyright>
+
    <license url="%licenseURL">
       %license
    </license>
 
-	<includes id="org.jboss.tools.common.core.feature" version="0.0.0" />
-	<includes id="org.jboss.tools.common.feature" version="0.0.0" />
-	<includes id="org.jboss.tools.common.text.ext.feature" version="0.0.0" />
-	<includes id="org.jboss.tools.common.ui.feature" version="0.0.0" />
-	<includes id="org.jboss.tools.common.verification.feature" version="0.0.0" />
+   <includes
+         id="org.jboss.tools.common.core.feature"
+         version="0.0.0"/>
 
-	<plugin id="org.jboss.tools.common.el.core" download-size="0" install-size="0" version="0.0.0" />
-	<plugin id="org.jboss.tools.common.el.ui" download-size="0" install-size="0" version="0.0.0" />
-	<plugin id="org.jboss.tools.common.meta.ui" download-size="0" install-size="0" version="0.0.0" />
-	<plugin id="org.jboss.tools.common.resref.core" download-size="0" install-size="0" version="0.0.0" />
-	<plugin id="org.jboss.tools.common.resref.ui" download-size="0" install-size="0" version="0.0.0" />
+   <includes
+         id="org.jboss.tools.common.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.jboss.tools.common.text.ext.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.jboss.tools.common.ui.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.jboss.tools.common.verification.feature"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.jboss.tools.common.el.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.jboss.tools.common.el.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.jboss.tools.common.meta.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.jboss.tools.common.resref.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.jboss.tools.common.resref.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
 </feature>

--- a/common/features/org.jboss.tools.common.all.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.all.feature/pom.xml
@@ -4,10 +4,10 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>features</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.all.feature</artifactId> 
-	<version>3.15.0-SNAPSHOT</version>
+	<version>3.15.100-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/common/features/org.jboss.tools.common.all.test.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.all.test.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>features</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.all.test.feature</artifactId>

--- a/common/features/org.jboss.tools.common.core.feature/feature.xml
+++ b/common/features/org.jboss.tools.common.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.common.core.feature"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.15.100.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.common.projecttemplates"
       license-feature="org.jboss.tools.foundation.license.feature"
@@ -19,6 +19,7 @@
    <license url="%licenseURL">
       %license
    </license>
+
    <plugin
          id="org.jboss.tools.common.core"
          download-size="0"
@@ -52,4 +53,5 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
 </feature>

--- a/common/features/org.jboss.tools.common.core.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.core.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>features</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.core.feature</artifactId> 

--- a/common/features/org.jboss.tools.common.feature/feature.xml
+++ b/common/features/org.jboss.tools.common.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.common.feature"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.15.100.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.common.el.ui"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/common/features/org.jboss.tools.common.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.feature/pom.xml
@@ -4,10 +4,10 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>features</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.feature</artifactId> 
-	<version>3.15.0-SNAPSHOT</version>
+	<version>3.15.100-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/common/features/org.jboss.tools.common.jdt.feature/feature.xml
+++ b/common/features/org.jboss.tools.common.jdt.feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="org.jboss.tools.common.jdt.feature" label="%featureName" version="3.15.0.qualifier" provider-name="%providerName" plugin="org.jboss.tools.common.jdt.debug"
+<feature id="org.jboss.tools.common.jdt.feature" label="%featureName" version="3.15.100.qualifier" provider-name="%providerName" plugin="org.jboss.tools.common.jdt.debug"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">
 

--- a/common/features/org.jboss.tools.common.jdt.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.jdt.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>features</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.jdt.feature</artifactId> 

--- a/common/features/org.jboss.tools.common.mylyn.feature/feature.xml
+++ b/common/features/org.jboss.tools.common.mylyn.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.common.mylyn.feature"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.15.100.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.common.mylyn"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/common/features/org.jboss.tools.common.mylyn.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.mylyn.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>features</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.mylyn.feature</artifactId> 

--- a/common/features/org.jboss.tools.common.text.ext.feature/feature.xml
+++ b/common/features/org.jboss.tools.common.text.ext.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.common.text.ext.feature"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.15.100.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.common.text.ext"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/common/features/org.jboss.tools.common.text.ext.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.text.ext.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>features</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.text.ext.feature</artifactId> 

--- a/common/features/org.jboss.tools.common.ui.feature/feature.xml
+++ b/common/features/org.jboss.tools.common.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.common.ui.feature"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.15.100.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.common.ui"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/common/features/org.jboss.tools.common.ui.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.ui.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>features</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.ui.feature</artifactId> 

--- a/common/features/org.jboss.tools.common.verification.feature/feature.xml
+++ b/common/features/org.jboss.tools.common.verification.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.common.verification.feature"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.15.100.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.common.verification.ui"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/common/features/org.jboss.tools.common.verification.feature/pom.xml
+++ b/common/features/org.jboss.tools.common.verification.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>features</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.features</groupId>
 	<artifactId>org.jboss.tools.common.verification.feature</artifactId> 

--- a/common/features/pom.xml
+++ b/common/features/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>	
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>common</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<modules>

--- a/common/plugins/org.jboss.tools.common.core/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.core/META-INF/MANIFEST.MF
@@ -40,7 +40,7 @@ Require-Bundle: org.eclipse.equinox.p2.core;bundle-version="2.3.0",
  org.apache.commons.httpclient;bundle-version="3.1.0",
  org.jboss.tools.foundation.core;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.jst.j2ee.web;bundle-version="1.1.800"
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/common/plugins/org.jboss.tools.common.core/pom.xml
+++ b/common/plugins/org.jboss.tools.common.core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.core</artifactId>

--- a/common/plugins/org.jboss.tools.common.el.core/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.el.core/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.el.core;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Export-Package: org.jboss.tools.common.el.core,
  org.jboss.tools.common.el.core.ca,
  org.jboss.tools.common.el.core.ca.preferences,

--- a/common/plugins/org.jboss.tools.common.el.core/pom.xml
+++ b/common/plugins/org.jboss.tools.common.el.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.el.core</artifactId> 

--- a/common/plugins/org.jboss.tools.common.el.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.el.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.el.ui;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Export-Package: org.jboss.tools.common.el.ui,
  org.jboss.tools.common.el.ui.ca,
  org.jboss.tools.common.el.ui.internal.info

--- a/common/plugins/org.jboss.tools.common.el.ui/pom.xml
+++ b/common/plugins/org.jboss.tools.common.el.ui/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.el.ui</artifactId> 
-	<version>3.15.0-SNAPSHOT</version>
+	<version>3.15.100-SNAPSHOT</version>
 	
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.jboss.tools.common.gef/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.gef/META-INF/MANIFEST.MF
@@ -27,6 +27,6 @@ Require-Bundle: org.jboss.tools.common,
  org.eclipse.gef;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.7.100"
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-BundleShape: dir

--- a/common/plugins/org.jboss.tools.common.gef/pom.xml
+++ b/common/plugins/org.jboss.tools.common.gef/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.gef</artifactId> 

--- a/common/plugins/org.jboss.tools.common.jaxb/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.jaxb/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-Name: %Bundle-Name.0
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.jboss.tools.common.jaxb;singleton:=true
 Bundle-Localization: plugin
-Bundle-Version: 3.15.1.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/common/plugins/org.jboss.tools.common.jaxb/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.jaxb/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-Name: %Bundle-Name.0
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.jboss.tools.common.jaxb;singleton:=true
 Bundle-Localization: plugin
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.1.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
@@ -122,4 +122,4 @@ Export-Package: com.sun.codemodel,
  org.kohsuke.rngom.xml.util,
  org.relaxng.datatype,
  org.relaxng.datatype.helpers
-Require-Bundle: javax.activation
+Require-Bundle: javax.activation;bundle-version="[1.0.0,2.0.0)"

--- a/common/plugins/org.jboss.tools.common.jaxb/pom.xml
+++ b/common/plugins/org.jboss.tools.common.jaxb/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.jaxb</artifactId>

--- a/common/plugins/org.jboss.tools.common.jaxb/pom.xml
+++ b/common/plugins/org.jboss.tools.common.jaxb/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.1-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.jaxb</artifactId>

--- a/common/plugins/org.jboss.tools.common.jdt.debug.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.jdt.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.common.jdt.debug.ui;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.jboss.tools.common.jdt.debug.ui.RemoteDebugUIActivator
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/common/plugins/org.jboss.tools.common.jdt.debug.ui/pom.xml
+++ b/common/plugins/org.jboss.tools.common.jdt.debug.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.jdt.debug.ui</artifactId> 

--- a/common/plugins/org.jboss.tools.common.jdt.debug/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.jdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.common.jdt.debug;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.jboss.tools.common.jdt.debug.RemoteDebugActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.7.100",

--- a/common/plugins/org.jboss.tools.common.jdt.debug/pom.xml
+++ b/common/plugins/org.jboss.tools.common.jdt.debug/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.jdt.debug</artifactId> 

--- a/common/plugins/org.jboss.tools.common.jdt.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.jdt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.common.jdt.ui;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.jboss.tools.common.jdt.ui.JDTExtUIActivator
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/common/plugins/org.jboss.tools.common.jdt.ui/pom.xml
+++ b/common/plugins/org.jboss.tools.common.jdt.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.jdt.ui</artifactId> 

--- a/common/plugins/org.jboss.tools.common.jdt/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.common.jdt;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.jboss.tools.common.jdt.core.JDTExtActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.jdt.core;bundle-version="3.7.0",

--- a/common/plugins/org.jboss.tools.common.jdt/pom.xml
+++ b/common/plugins/org.jboss.tools.common.jdt/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.jdt</artifactId> 

--- a/common/plugins/org.jboss.tools.common.meta.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.meta.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.meta.ui;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.jboss.tools.common.model,

--- a/common/plugins/org.jboss.tools.common.meta.ui/pom.xml
+++ b/common/plugins/org.jboss.tools.common.meta.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.meta.ui</artifactId> 

--- a/common/plugins/org.jboss.tools.common.model.ui.capabilities/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.model.ui.capabilities/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.jboss.tools.common.model.ui.capabilities;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0"

--- a/common/plugins/org.jboss.tools.common.model.ui.capabilities/pom.xml
+++ b/common/plugins/org.jboss.tools.common.model.ui.capabilities/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.model.ui.capabilities</artifactId> 

--- a/common/plugins/org.jboss.tools.common.model.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.model.ui/META-INF/MANIFEST.MF
@@ -92,7 +92,7 @@ Require-Bundle: org.jboss.tools.common.model;visibility:=reexport,
  org.jboss.tools.common.ui;visibility:=reexport,
  org.eclipse.jst.standard.schemas;bundle-version="1.2.0",
  org.eclipse.wst.standard.schemas
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: org.jboss.tools.common.model.ui.jar
 Eclipse-BundleShape: dir

--- a/common/plugins/org.jboss.tools.common.model.ui/pom.xml
+++ b/common/plugins/org.jboss.tools.common.model.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.model.ui</artifactId> 

--- a/common/plugins/org.jboss.tools.common.model/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.model/META-INF/MANIFEST.MF
@@ -89,7 +89,7 @@ Require-Bundle: org.jboss.tools.common;visibility:=reexport,
  org.eclipse.core.filesystem,
  org.jboss.tools.common.model.ui.capabilities;bundle-version="3.6.0",
  org.eclipse.jdt.core.manipulation
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: org.jboss.tools.common.model.jar
 Eclipse-BundleShape: dir

--- a/common/plugins/org.jboss.tools.common.model/pom.xml
+++ b/common/plugins/org.jboss.tools.common.model/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.model</artifactId> 

--- a/common/plugins/org.jboss.tools.common.mylyn/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.mylyn/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Tools Mylyn Connections
 Bundle-SymbolicName: org.jboss.tools.common.mylyn;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.mylyn.commons.core;bundle-version="[3.8.0,4.0.0)",

--- a/common/plugins/org.jboss.tools.common.mylyn/pom.xml
+++ b/common/plugins/org.jboss.tools.common.mylyn/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.mylyn</artifactId>

--- a/common/plugins/org.jboss.tools.common.projecttemplates/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.projecttemplates/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-SymbolicName: org.jboss.tools.common.projecttemplates;singleton:=true
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.ui;bundle-version="3.7.0",
  org.jboss.tools.common
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-BundleShape: dir

--- a/common/plugins/org.jboss.tools.common.projecttemplates/pom.xml
+++ b/common/plugins/org.jboss.tools.common.projecttemplates/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.projecttemplates</artifactId> 

--- a/common/plugins/org.jboss.tools.common.resref.core/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.resref.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.resref.core;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.jboss.tools.common.resref.core.ResourceReferencePlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.7.100",

--- a/common/plugins/org.jboss.tools.common.resref.core/pom.xml
+++ b/common/plugins/org.jboss.tools.common.resref.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.resref.core</artifactId> 

--- a/common/plugins/org.jboss.tools.common.resref.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.resref.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.resref.ui;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.jboss.tools.common.resref.ui.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/common/plugins/org.jboss.tools.common.resref.ui/pom.xml
+++ b/common/plugins/org.jboss.tools.common.resref.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.resref.ui</artifactId> 

--- a/common/plugins/org.jboss.tools.common.text.ext/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.text.ext/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Export-Package: org.jboss.tools.common.text.ext,
  org.jboss.tools.common.text.ext.hyperlink.xpl,
  org.jboss.tools.common.text.ext.util,
  org.jboss.tools.common.text.ext.util.xpl
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Name: %Bundle-Name.0
 Bundle-ManifestVersion: 2
 Bundle-Vendor: %providerName

--- a/common/plugins/org.jboss.tools.common.text.ext/pom.xml
+++ b/common/plugins/org.jboss.tools.common.text.ext/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.text.ext</artifactId> 

--- a/common/plugins/org.jboss.tools.common.text.xml/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.text.xml/META-INF/MANIFEST.MF
@@ -30,6 +30,6 @@ Require-Bundle: org.jboss.tools.common,
  org.eclipse.wst.dtd.ui;bundle-version="1.0.600",
  org.junit;bundle-version="4.12.0",
  org.eclipse.ui.ide;bundle-version="3.7.0"
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .

--- a/common/plugins/org.jboss.tools.common.text.xml/pom.xml
+++ b/common/plugins/org.jboss.tools.common.text.xml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.text.xml</artifactId> 

--- a/common/plugins/org.jboss.tools.common.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-Name: %Bundle-Name.0
 Bundle-Activator: org.jboss.tools.common.ui.CommonUIPlugin
 Bundle-SymbolicName: org.jboss.tools.common.ui;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Require-Bundle: org.eclipse.osgi;bundle-version="3.7.0",
  org.jboss.tools.common,
  org.eclipse.ui;bundle-version="3.7.0",

--- a/common/plugins/org.jboss.tools.common.ui/pom.xml
+++ b/common/plugins/org.jboss.tools.common.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.ui</artifactId> 

--- a/common/plugins/org.jboss.tools.common.validation/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.validation;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.jboss.tools.common.validation.CommonValidationPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/common/plugins/org.jboss.tools.common.validation/pom.xml
+++ b/common/plugins/org.jboss.tools.common.validation/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.validation</artifactId> 

--- a/common/plugins/org.jboss.tools.common.verification.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.verification.ui/META-INF/MANIFEST.MF
@@ -30,5 +30,5 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="3.7.0",
  org.eclipse.jface;bundle-version="3.7.0",
  org.eclipse.wst.common.project.facet.core;bundle-version="1.4.200",
  org.eclipse.wst.validation;bundle-version="1.2.300"
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/common/plugins/org.jboss.tools.common.verification.ui/pom.xml
+++ b/common/plugins/org.jboss.tools.common.verification.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.verification.ui</artifactId> 

--- a/common/plugins/org.jboss.tools.common.verification/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common.verification/META-INF/MANIFEST.MF
@@ -22,5 +22,5 @@ Require-Bundle: org.jboss.tools.common,
  org.eclipse.core.resources;bundle-version="3.7.100",
  org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.wst.validation;bundle-version="1.2.300"
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/common/plugins/org.jboss.tools.common.verification/pom.xml
+++ b/common/plugins/org.jboss.tools.common.verification/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.verification</artifactId> 

--- a/common/plugins/org.jboss.tools.common/META-INF/MANIFEST.MF
+++ b/common/plugins/org.jboss.tools.common/META-INF/MANIFEST.MF
@@ -36,7 +36,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.yaml.snakeyaml;bundle-version="1.21.0",
  org.apache.httpcomponents.httpclient;bundle-version="4.5.6",
  org.apache.httpcomponents.httpcore;bundle-version="4.4.10"
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/common/plugins/org.jboss.tools.common/pom.xml
+++ b/common/plugins/org.jboss.tools.common/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common</artifactId> 

--- a/common/plugins/pom.xml
+++ b/common/plugins/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>	
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>common</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<modules>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>common</artifactId>
 	<name>common.all</name>
-	<version>3.15.0-SNAPSHOT</version>
+	<version>3.15.100-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
 		<enforceFailOnUIDependencyInCore>false</enforceFailOnUIDependencyInCore>

--- a/common/test-framework/org.jboss.tools.common.reddeer/META-INF/MANIFEST.MF
+++ b/common/test-framework/org.jboss.tools.common.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Common UI Tests
 Bundle-SymbolicName: org.jboss.tools.common.reddeer
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.jboss.tools.common.reddeer.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.reddeer.go;bundle-version="2.1.0",

--- a/common/test-framework/org.jboss.tools.common.reddeer/pom.xml
+++ b/common/test-framework/org.jboss.tools.common.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>test-framework</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.test-framework</groupId>
 	<artifactId>org.jboss.tools.common.reddeer</artifactId>

--- a/common/test-framework/pom.xml
+++ b/common/test-framework/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>	
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>common</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 
 	<packaging>pom</packaging>	

--- a/common/tests/org.jboss.tools.common.base.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.base.test/META-INF/MANIFEST.MF
@@ -38,6 +38,6 @@ Require-Bundle: org.jboss.tools.common,
  org.eclipse.search;bundle-version="3.7.0",
  org.jboss.tools.common.ui,
  org.jboss.tools.common.model.ui
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .

--- a/common/tests/org.jboss.tools.common.base.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.base.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.plugins</groupId>
 	<artifactId>org.jboss.tools.common.base.test</artifactId> 

--- a/common/tests/org.jboss.tools.common.core.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.core.test;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Vendor: %Bundle-Vendor.0
 Export-Package: org.jboss.tools.common.core.test
 Require-Bundle: 

--- a/common/tests/org.jboss.tools.common.core.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.core.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.core.test</artifactId>

--- a/common/tests/org.jboss.tools.common.el.core.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.el.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.el.core.test;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %Bundle-Vendor.0
 Export-Package: org.jboss.tools.common.el.core.test

--- a/common/tests/org.jboss.tools.common.el.core.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.el.core.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.el.core.test</artifactId>

--- a/common/tests/org.jboss.tools.common.model.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.model.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.model.test;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Vendor: %Bundle-Vendor.0
 Export-Package: org.jboss.tools.common.model.test,
  org.jboss.tools.common.model.util.test

--- a/common/tests/org.jboss.tools.common.model.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.model.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.model.test</artifactId>

--- a/common/tests/org.jboss.tools.common.model.ui.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.model.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.model.ui.test;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Require-Bundle: org.junit;bundle-version="4.12.0";visibility:=reexport,
  org.eclipse.jface,
  org.jboss.tools.tests,

--- a/common/tests/org.jboss.tools.common.model.ui.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.model.ui.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.model.ui.test</artifactId>

--- a/common/tests/org.jboss.tools.common.mylyn.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.mylyn.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.mylyn.test</artifactId>

--- a/common/tests/org.jboss.tools.common.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.test
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Vendor: %Bundle-Vendor.0
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/common/tests/org.jboss.tools.common.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.test</artifactId>

--- a/common/tests/org.jboss.tools.common.text.ext.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.text.ext.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.text.ext.test;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Require-Bundle: org.junit;bundle-version="4.12.0";visibility:=reexport,
  org.eclipse.wst.html.core,
  org.jboss.tools.common.text.ext;bundle-version="3.6.0",

--- a/common/tests/org.jboss.tools.common.text.ext.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.text.ext.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.text.ext.test</artifactId>

--- a/common/tests/org.jboss.tools.common.ui.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.ui.test
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Vendor: %Bundle-Vendor.0
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/common/tests/org.jboss.tools.common.ui.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.ui.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.ui.test</artifactId>

--- a/common/tests/org.jboss.tools.common.validation.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.validation.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Common Validation Test
 Bundle-SymbolicName: org.jboss.tools.common.validation.test;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.jboss.tools.tests,

--- a/common/tests/org.jboss.tools.common.validation.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.validation.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.validation.test</artifactId> 

--- a/common/tests/org.jboss.tools.common.verification.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.verification.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.common.verification.test;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %Bundle-Vendor.0
 Export-Package: org.jboss.tools.common.verification.test

--- a/common/tests/org.jboss.tools.common.verification.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.verification.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.verification.test</artifactId>

--- a/common/tests/org.jboss.tools.common.verification.ui.test/META-INF/MANIFEST.MF
+++ b/common/tests/org.jboss.tools.common.verification.ui.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-Vendor: %BundleVendor
 Bundle-SymbolicName: org.jboss.tools.common.verification.ui.test
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Require-Bundle: org.junit,
  org.jboss.tools.tests,
  org.eclipse.jface,

--- a/common/tests/org.jboss.tools.common.verification.ui.test/pom.xml
+++ b/common/tests/org.jboss.tools.common.verification.ui.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.common</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.common.tests</groupId>
 	<artifactId>org.jboss.tools.common.verification.ui.test</artifactId>

--- a/common/tests/pom.xml
+++ b/common/tests/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>	
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>common</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.15.100-SNAPSHOT</version>
 	</parent>
 
 	<packaging>pom</packaging>

--- a/jacoco-report/pom.xml
+++ b/jacoco-report/pom.xml
@@ -15,7 +15,7 @@
 	<properties>
 		<sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 		<enforceExcludePatternExtras>|plugins.version.*</enforceExcludePatternExtras>
-		<plugins.version.common>3.15.0-SNAPSHOT</plugins.version.common>
+		<plugins.version.common>3.15.100-SNAPSHOT</plugins.version.common>
 		<plugins.version.foundation>1.6.600-SNAPSHOT</plugins.version.foundation>
 		<plugins.version.runtime>3.5.100-SNAPSHOT</plugins.version.runtime>
 		<plugins.version.stacks>1.4.103-SNAPSHOT</plugins.version.stacks>


### PR DESCRIPTION
a range needs to be added because the version 2.0 is using
jakarta.activation.\*, no more javax.activation.\*

the issue appeared with introduction of javax.activation 2.0.0 in Target Platform